### PR TITLE
Add dev logging: capture errors, panics, and tracing output to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "bisque-computer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -262,6 +262,9 @@ dependencies = [
  "skrifa",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "url",
  "vello",
  "winit",
@@ -660,6 +663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +710,15 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1595,6 +1616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1878,6 +1914,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -2464,6 +2515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,6 +3268,37 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3384,7 +3490,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3394,6 +3524,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3490,6 +3650,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ serde_json = "1"
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
 
+# Structured logging (dev file logging via BISQUE_LOG=1)
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"] }
+tracing-appender = "0.2"
+
 # CLI argument parsing
 clap = { version = "4", features = ["derive"] }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,139 @@
+//! Dev logging module for bisque-computer.
+//!
+//! Enabled by setting the `BISQUE_LOG` environment variable to any non-empty value
+//! before launching the app:
+//!
+//! ```sh
+//! BISQUE_LOG=1 bisque-computer
+//! ```
+//!
+//! When active, all `tracing` events (info, warn, error, debug, trace) are written
+//! to `~/bisque-computer.log` with RFC 3339 timestamps and log levels. A custom
+//! panic hook is also installed so that panics are recorded to the log file before
+//! the default panic handler runs.
+//!
+//! When `BISQUE_LOG` is not set the function is a no-op and returns `None`, leaving
+//! stdout/stderr behaviour identical to the unlogged build.
+
+use std::path::PathBuf;
+
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::prelude::*;
+
+/// Initialise file-based logging if `BISQUE_LOG` is set.
+///
+/// Returns an `Option<WorkerGuard>` that **must be kept alive** for the
+/// duration of the process. Dropping it flushes and closes the log file.
+/// Store the returned guard in a local binding in `main()`.
+///
+/// # Behaviour
+///
+/// - Log file: `~/bisque-computer.log` (created or appended on each run).
+/// - Format: `YYYY-MM-DDTHH:MM:SSZ  LEVEL  target: message`
+/// - Panic hook: captures the panic location and message, writes them as an
+///   ERROR event, then calls the previous panic handler so the process still
+///   aborts with a backtrace.
+///
+/// # Example
+///
+/// ```rust
+/// let _log_guard = logging::init();
+/// ```
+pub fn init() -> Option<WorkerGuard> {
+    // Only activate when the user explicitly opts in.
+    if std::env::var("BISQUE_LOG").unwrap_or_default().is_empty() {
+        return None;
+    }
+
+    let log_path = log_file_path();
+
+    // Ensure the parent directory exists (it's always ~/, which exists, but
+    // be defensive for unusual $HOME configurations).
+    if let Some(parent) = log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    // Open the log file for appending (create it if absent).
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .expect("bisque-computer: failed to open log file");
+
+    // Wrap in a non-blocking writer. The returned guard must be kept alive.
+    let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
+
+    // Build a subscriber that writes timestamped plain-text lines.
+    // SystemTime is always available (no extra feature flags required).
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking)
+            .with_ansi(false) // no colour codes in the file
+            .with_timer(tracing_subscriber::fmt::time::SystemTime)
+            .with_target(true)
+            .with_thread_ids(false)
+            .with_file(false),
+    );
+
+    // Install as the global default. Panics if a subscriber is already set,
+    // which should not happen in normal usage.
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("bisque-computer: failed to set global tracing subscriber");
+
+    // Install the panic hook *after* the subscriber is live so tracing::error!
+    // will actually reach the file writer.
+    install_panic_hook();
+
+    let display_path = log_path.display().to_string();
+    tracing::info!("bisque-computer logging initialised — writing to {}", display_path);
+    eprintln!("[bisque] logging to {}", display_path);
+
+    Some(guard)
+}
+
+/// Return the absolute path for the log file: `~/bisque-computer.log`.
+fn log_file_path() -> PathBuf {
+    let home = std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"));
+    home.join("bisque-computer.log")
+}
+
+/// Install a panic hook that logs the panic as a `tracing::error!` event
+/// before delegating to the previously-installed handler (usually the default
+/// Rust panic handler that prints a backtrace and aborts).
+///
+/// This is a pure function in the sense that it only captures the previous
+/// hook via `std::panic::take_hook` and composes a new closure around it —
+/// the side-effectful registration is isolated here at the boundary.
+fn install_panic_hook() {
+    let prev_hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |info| {
+        // Extract location (file:line) if available.
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}", l.file(), l.line()))
+            .unwrap_or_else(|| "<unknown location>".to_string());
+
+        // Extract the panic message (works for both `panic!("msg")` and
+        // `panic!("{}", expr)` since PanicInfo::payload() is `dyn Any`).
+        let message = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "<non-string panic payload>".to_string()
+        };
+
+        tracing::error!(
+            location = %location,
+            "PANIC: {}",
+            message
+        );
+
+        // Delegate to the previous handler so the process still aborts with
+        // the standard Rust panic output (backtrace, etc.).
+        prev_hook(info);
+    }));
+}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -12,6 +12,7 @@ use cpal::{SampleFormat, SampleRate, StreamConfig};
 use std::io::Cursor;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use tracing::{error, warn};
 
 /// Configuration for the voice input subsystem.
 #[derive(Debug, Clone)]
@@ -138,7 +139,7 @@ fn build_f32_stream(
                 }
             }
         },
-        |err| eprintln!("Audio stream error: {}", err),
+        |err| error!(target: "voice", "Audio stream error: {}", err),
         None,
     )?;
     Ok(stream)
@@ -159,7 +160,7 @@ fn build_i16_stream(
                 }
             }
         },
-        |err| eprintln!("Audio stream error: {}", err),
+        |err| error!(target: "voice", "Audio stream error: {}", err),
         None,
     )?;
     Ok(stream)
@@ -183,7 +184,7 @@ fn build_u16_stream(
                 }
             }
         },
-        |err| eprintln!("Audio stream error: {}", err),
+        |err| error!(target: "voice", "Audio stream error: {}", err),
         None,
     )?;
     Ok(stream)
@@ -399,7 +400,8 @@ pub async fn transcribe(wav_bytes: Vec<u8>, config: &VoiceConfig) -> Result<Tran
     match transcribe_via_server(wav_bytes.clone(), &config.whisper_host, config.whisper_port).await {
         Ok(result) => Ok(result),
         Err(server_err) => {
-            eprintln!(
+            warn!(
+                target: "voice",
                 "whisper HTTP server unavailable ({}), falling back to CLI",
                 server_err
             );


### PR DESCRIPTION
Closes #5

## Summary

Adds a dev/debug logging system to bisque-computer. When `BISQUE_LOG=1` is set in the environment before launching the app, all structured log events, errors, and panics are written to `~/bisque-computer.log`.

- `BISQUE_LOG=1 bisque-computer` activates file logging; without it behaviour is identical to the previous release
- Log file: `~/bisque-computer.log` (created if absent, appended on subsequent runs)
- Each line is prefixed with a wall-clock timestamp and log level
- Panics are intercepted by a custom hook, recorded as ERROR events with file/line location, then the default handler runs so the process still aborts normally
- All `println!`/`eprintln!` calls replaced with `tracing::{info, warn, error}` macros so every message goes through the structured pipeline

## Files changed

| File | What changed |
|------|-------------|
| `Cargo.toml` | Added `tracing`, `tracing-subscriber` (fmt + env-filter + ansi), `tracing-appender` |
| `src/logging.rs` | New module: `init()` sets up non-blocking file writer and panic hook; returns `WorkerGuard` to hold in `main()` |
| `src/main.rs` | Declare `mod logging`; call `logging::init()` at startup; replace all print macros with tracing macros |
| `src/ws_client.rs` | Replace `eprintln!` with tracing; add structured connection lifecycle events |
| `src/voice.rs` | Replace `eprintln!` in stream error callbacks and transcription fallback with tracing macros |

## Functional patterns used

- `logging::init()` is a pure factory: it takes no mutable global state as arguments and returns the guard as a value — the caller owns the lifetime
- The panic hook is composed functionally: `take_hook()` captures the previous handler, and the new closure closes over it, chaining behaviour without mutation of shared state
- The non-blocking writer is a pure transform: `tracing_appender::non_blocking(file)` wraps the sink and returns `(writer, guard)` — side effects isolated to the boundary

## Test plan

- [ ] Set `BISQUE_LOG=1` and launch; verify `~/bisque-computer.log` is created with startup entries
- [ ] Connect to a Lobster server; verify connection events appear in the log
- [ ] Use Shift+Enter voice input; verify transcription events are logged
- [ ] Launch without `BISQUE_LOG`; verify no log file is created and app behaves as before
- [ ] Trigger a recoverable error (e.g. bad server URL); verify error appears in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)