### PR TITLE
fix(terminal): use confirmed cell fg color for prediction overlay

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@
 mod dashboard;
 #[allow(dead_code)]
 mod design;
+#[allow(dead_code)]
+pub mod prediction;
 mod design_repl;
 mod info_screen;
 mod logging;

--- a/src/prediction/INTEGRATION.md
+++ b/src/prediction/INTEGRATION.md
@@ -1,0 +1,342 @@
+# Mosh-style Prediction Engine: Integration Guide
+
+This guide explains how to wire `PredictionEngine` into bisque-computer's
+terminal render loop. The prediction module lives in `src/prediction/` and
+is self-contained — it does not depend on `alacritty_terminal` or `vello`.
+
+---
+
+## Architecture Overview
+
+The prediction engine sits between key input and rendering:
+
+```
+winit KeyEvent
+    │
+    ▼
+PredictionEngine::process_input(key)
+    │
+    ├── InputClass::Predictable(ch) → insert cell into overlay
+    ├── InputClass::Uncertain → become_tentative() (hide subsequent predictions)
+    ├── InputClass::Backspace → pop last cell, move cursor left
+    ├── InputClass::Arrow{Left,Right} → move cursor prediction
+    └── InputClass::Bulk → reset()
+    │
+    ▼
+[bytes sent to WebSocket → server → tmux → shell]
+    │
+    (after some RTT...)
+    │
+    ▼
+server PTY bytes arrive
+    │
+    ▼
+PredictionEngine::process_server_output(bytes)
+    │
+    ├── match: remove confirmed cells from overlay
+    └── mismatch: wipe all predictions, snap cursor
+
+                    ┌──────────────┐
+                    │  render loop │
+                    └──────┬───────┘
+                           │
+                    alacritty_terminal::Term
+                    (confirmed server state)
+                           │
+                           ▼
+                    render_into_scene()
+                           │
+                    paint overlay cells on top
+                    (PredictionEngine::overlay())
+                           │
+                           ▼
+                    vello Scene → GPU
+```
+
+---
+
+## Step 1: Initialize PredictionEngine
+
+Create a `PredictionEngine` alongside `TerminalPane`. The engine needs to know
+the terminal dimensions for cursor clamping.
+
+```rust
+use crate::prediction::PredictionEngine;
+
+struct TerminalPane {
+    // ... existing fields ...
+    prediction: PredictionEngine,
+}
+
+impl TerminalPane {
+    pub fn new(cols: u16, rows: u16) -> Self {
+        Self {
+            // ... existing init ...
+            prediction: PredictionEngine::new(cols, rows),
+        }
+    }
+}
+```
+
+---
+
+## Step 2: Wire Key Events into the Engine
+
+In `write_key()` (in `terminal.rs`), call `process_input` before sending bytes
+to the WebSocket. Convert the winit `Key` to the engine's `KeyEvent` type.
+
+```rust
+use crate::prediction::{KeyEvent as PredKeyEvent, PredictionEngine};
+
+pub fn write_key(&mut self, key: &Key, ctrl_held: bool) -> bool {
+    let bytes = key_event_to_pty_bytes(key, ctrl_held, app_cursor);
+    if bytes.is_empty() {
+        return false;
+    }
+
+    // Feed the keystroke to the prediction engine BEFORE sending to server.
+    // This ensures the overlay is updated synchronously with the render frame.
+    let pred_key = PredKeyEvent {
+        bytes: bytes.clone(),
+        ctrl_held,
+    };
+    self.prediction.process_input(&pred_key);
+
+    // Send the bytes to the WebSocket as before.
+    self.writer.write_all(&bytes).ok();
+    true
+}
+```
+
+**Important:** Do not modify the bytes going to the WebSocket. The prediction
+engine is purely additive — it does not alter what is sent to the server.
+
+---
+
+## Step 3: Feed Server Output to the Engine
+
+In `drain_output()` (or wherever WebSocket bytes are fed into
+`alacritty_terminal::Term`), also call `process_server_output`:
+
+```rust
+pub fn drain_output(&mut self) {
+    while let Ok(bytes) = self.output_rx.try_recv() {
+        // Feed bytes to the prediction engine for confirmation/mismatch detection.
+        self.prediction.process_server_output(&bytes);
+
+        // Feed bytes to alacritty_terminal as before.
+        self.term_processor.advance(&mut self.term, &bytes);
+    }
+
+    // After processing all server output, sync the confirmed cursor position.
+    let cursor = self.term.grid().cursor.point;
+    self.prediction.sync_confirmed_cursor(
+        cursor.column.0 as u16,
+        cursor.line.0 as u16,
+    );
+}
+```
+
+---
+
+## Step 4: Update RTT from WebSocket Ping/Pong
+
+Wire RTT measurement into the engine. The WebSocket connection already has
+access to ping/pong timing — update the engine when RTT changes:
+
+```rust
+// In ws_client.rs or wherever ping/pong timing is measured:
+fn on_pong_received(&mut self, rtt_ms: u32) {
+    self.terminal.prediction.set_rtt(rtt_ms);
+}
+```
+
+The engine uses hysteresis:
+- RTT >= 20ms → predictions activated
+- RTT < 20ms with no pending predictions → predictions deactivated
+- RTT > 80ms → predictions shown with underline (flagging mode)
+
+---
+
+## Step 5: Paint the Overlay in render_into_scene()
+
+In `render_into_scene()` (in `terminal.rs`), after rendering the base
+`alacritty_terminal` grid, iterate the overlay and paint on top:
+
+```rust
+pub fn render_into_scene(&self, scene: &mut Scene, /* ... */) {
+    // --- Phase 1: Render confirmed terminal state (existing code) ---
+    let content = self.term.renderable_content();
+    for cell in content.display_iter {
+        // ... existing cell rendering ...
+    }
+
+    // --- Phase 2: Paint prediction overlay on top ---
+    let confirmed_epoch = self.prediction.confirmed_epoch();
+
+    for ((col, row), overlay_cell) in self.prediction.overlay().visible_cells(confirmed_epoch) {
+        let x = left_margin + col as f32 * cell_width;
+        let y = top_margin + row as f32 * cell_height;
+
+        // Use a slightly different style for predicted cells:
+        // - Same color as normal text
+        // - Underlined if overlay_cell.underlined (RTT > 80ms)
+        render_predicted_cell(scene, x, y, overlay_cell.ch, overlay_cell.underlined);
+    }
+
+    // --- Phase 3: Paint predicted cursor ---
+    let (pred_col, pred_row) = self.prediction.predicted_cursor();
+    render_cursor(scene, pred_col, pred_row, /* cursor style */);
+}
+```
+
+The `visible_cells(confirmed_epoch)` iterator automatically filters out cells
+whose epoch has not yet been confirmed by the server. You do not need to check
+epochs manually.
+
+---
+
+## Step 6: Handle Terminal Resize
+
+On resize, call `set_terminal_size()` to clamp the predicted cursor and reset
+all predictions (a resize invalidates everything):
+
+```rust
+pub fn resize(&mut self, cols: u16, rows: u16) {
+    self.term.resize(/* ... */);
+    self.prediction.set_terminal_size(cols, rows);
+    // prediction.reset() is called internally by set_terminal_size()
+}
+```
+
+---
+
+## The tmux Caveat (Critical for bisque-computer)
+
+bisque-computer always connects through tmux. This is the primary operational
+difference from Mosh's direct PTY use case.
+
+### Why tmux breaks naive prediction
+
+1. **Modal editor problem**: When the inner pane runs vim, the user is in normal
+   mode. Typing `j` moves down a line — the prediction engine will show `j` at
+   the cursor, which is immediately wrong. The misprediction is visible for 1
+   RTT before the server corrects it.
+
+2. **Echo delay**: tmux adds its own processing latency even on localhost. The
+   effective RTT seen by the prediction engine is slightly higher than the raw
+   WebSocket RTT.
+
+3. **tmux escape sequences**: tmux wraps inner terminal escape sequences in its
+   own passthrough format. The prediction engine ignores escape sequences, which
+   is correct — but it means tmux-added control bytes do not interfere.
+
+### Mitigation: OSC 133 Shell Integration
+
+The cleanest solution is OSC 133 shell prompt detection. When the server-side
+shell emits `ESC ] 133 ; A ST` (prompt start) and `ESC ] 133 ; B ST` (prompt
+end), bisque knows the inner pane is at a shell prompt — safe to predict.
+
+**Server side (bash/zsh):**
+```bash
+# Add to ~/.bashrc or ~/.zshrc inside the tmux session:
+PS1='\e]133;A\a'"$PS1"'\e]133;B\a'
+```
+
+**Client side (bisque-computer):**
+```rust
+// In drain_output(), scan for OSC 133 sequences:
+fn check_shell_integration(bytes: &[u8]) -> Option<ShellPromptState> {
+    // Look for ESC ] 133 ; A ST (prompt start) → ShellPromptState::AtPrompt
+    // Look for ESC ] 133 ; B ST (prompt end) → ShellPromptState::Running
+    // ...
+}
+
+// Gate prediction on prompt state:
+if shell_state == ShellPromptState::AtPrompt {
+    self.prediction.set_rtt(measured_rtt);
+} else {
+    // In vim, htop, etc. — disable predictions
+    self.prediction.set_rtt(0); // below activation threshold
+}
+```
+
+### Fallback: Alternate Screen Detection
+
+When any application enters alternate screen mode (vim, htop, nano), the server
+sends `ESC [ ? 1049 h`. The prediction engine should be suspended:
+
+```rust
+// Monitor alacritty_terminal for alternate screen mode changes:
+let is_alt_screen = self.term.mode().contains(TermMode::ALT_SCREEN);
+if is_alt_screen {
+    self.prediction.reset();
+    self.prediction.set_rtt(0); // disable
+}
+```
+
+This prevents mispredictions in vim while still providing predictions at the
+shell prompt (which uses the primary screen).
+
+### Conservative Threshold for tmux
+
+If neither OSC 133 nor alternate screen detection is implemented, use a
+conservative RTT threshold:
+
+```rust
+// Only activate predictions at very high RTT (>100ms) where even brief
+// mispredictions are less jarring than 200ms+ of lag.
+const TMUX_CONSERVATIVE_THRESHOLD_MS: u32 = 100;
+
+// Modify the activation check:
+if measured_rtt >= TMUX_CONSERVATIVE_THRESHOLD_MS {
+    prediction.set_rtt(measured_rtt);
+}
+```
+
+---
+
+## What the Server Needs to Do
+
+**Nothing special.** The prediction engine works entirely client-side. The
+server streams raw PTY bytes exactly as it does today. No protocol changes are
+required for Phase 1 (single-client, byte-level confirmation).
+
+The engine compares printable bytes in the server stream against its predicted
+bytes. Control sequences from the server are ignored during comparison. This is
+imprecise (it cannot distinguish "echo of typed char" from "server-generated
+char that happens to match"), but works well in practice for shell prompts.
+
+**Optional — frame sequence numbers:** For more precise confirmation, add
+sequence numbers to WebSocket frames (see issue #36 for the full protocol
+extension design). This allows exact per-character confirmation timing. Not
+required for Phase 1.
+
+---
+
+## Summary of Integration Points
+
+| Where | What |
+|-------|------|
+| `write_key()` | Call `prediction.process_input(&key)` before WebSocket send |
+| `drain_output()` | Call `prediction.process_server_output(bytes)` and `sync_confirmed_cursor()` |
+| `render_into_scene()` | Paint `overlay().visible_cells(confirmed_epoch)` on top of Term grid |
+| `resize()` | Call `prediction.set_terminal_size(cols, rows)` |
+| Ping/pong handler | Call `prediction.set_rtt(rtt_ms)` |
+| Alternate screen detect | Call `prediction.reset()` and `set_rtt(0)` when entering alt screen |
+| OSC 133 detect (optional) | Call `set_rtt(0)` when not at shell prompt |
+
+---
+
+## Phased Rollout Plan
+
+**Phase 1 (current implementation):** Byte-level comparison, all predictions
+visible immediately (no tentative gating by default), conservative RTT
+threshold for tmux. Implement the 6 integration points above.
+
+**Phase 2:** Add OSC 133 shell integration to gate predictions on prompt state.
+Add alternate screen detection to disable predictions in vim/htop/etc.
+
+**Phase 3:** Add frame sequence numbers to the WebSocket protocol for exact
+per-character confirmation. This enables precise epoch advancement and cleaner
+handling of tentative predictions after Ctrl sequences.

--- a/src/prediction/epoch.rs
+++ b/src/prediction/epoch.rs
@@ -1,0 +1,218 @@
+//! Epoch tracking for the Mosh-style prediction engine.
+//!
+//! The epoch system is the core concurrency-safety mechanism that prevents
+//! the prediction engine from showing predictions whose underlying state has
+//! been invalidated by unconfirmed control-key input.
+//!
+//! ## How epochs work
+//!
+//! `prediction_epoch` is a monotonically increasing counter. It is incremented
+//! every time the user types something "uncertain" — a Ctrl key, CR, ESC, or
+//! any other input whose terminal effect we cannot safely predict (e.g. Ctrl+C
+//! might kill the foreground process and change the terminal state completely).
+//!
+//! Every prediction is tagged with a `tentative_until_epoch` value equal to
+//! `prediction_epoch` at the time it was created. A prediction is only *shown*
+//! when `confirmed_epoch >= tentative_until_epoch`.
+//!
+//! `confirmed_epoch` advances when server output is received that matches a
+//! prediction — i.e., the server has "caught up" to a known state.
+//!
+//! The result: after a Ctrl+C, new predictions become tentative (invisible)
+//! until the server sends output that advances `confirmed_epoch` past the
+//! epoch that was current when Ctrl+C was typed.
+
+/// Tracks the prediction/confirmation epoch pair.
+///
+/// This is a pure-data type with no hidden state. All mutation is explicit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EpochTracker {
+    /// Monotonically increasing counter. Incremented on uncertain input.
+    /// New predictions are tagged `tentative_until = prediction_epoch`.
+    prediction_epoch: u64,
+
+    /// Advances as server output confirms our predictions.
+    /// A prediction tagged `tentative_until_epoch = N` is visible only when
+    /// `confirmed_epoch >= N`.
+    confirmed_epoch: u64,
+}
+
+impl EpochTracker {
+    /// Create a new EpochTracker with both epochs at zero.
+    pub fn new() -> Self {
+        Self {
+            prediction_epoch: 0,
+            confirmed_epoch: 0,
+        }
+    }
+
+    /// The current prediction epoch. New predictions are tagged with this value.
+    pub fn prediction_epoch(&self) -> u64 {
+        self.prediction_epoch
+    }
+
+    /// The current confirmed epoch. Predictions tagged <= this are visible.
+    pub fn confirmed_epoch(&self) -> u64 {
+        self.confirmed_epoch
+    }
+
+    /// Increment the prediction epoch due to uncertain input (Ctrl key, CR, ESC).
+    ///
+    /// After this call, any new predictions will be invisible until the server
+    /// sends output that advances `confirmed_epoch` past the new value.
+    pub fn become_tentative(&mut self) {
+        self.prediction_epoch = self.prediction_epoch.saturating_add(1);
+    }
+
+    /// Advance the confirmed epoch, making tentative predictions visible.
+    ///
+    /// Called when server output is received that matches a prediction,
+    /// confirming that the server has processed input up to a certain point.
+    ///
+    /// The confirmed epoch never exceeds the prediction epoch — we cannot
+    /// confirm epochs we haven't predicted yet.
+    pub fn advance_confirmed(&mut self) {
+        if self.confirmed_epoch < self.prediction_epoch {
+            self.confirmed_epoch = self.confirmed_epoch.saturating_add(1);
+        }
+    }
+
+    /// Check whether a prediction tagged with the given epoch is currently visible.
+    ///
+    /// A prediction is visible when `confirmed_epoch >= tentative_until_epoch`.
+    pub fn is_confirmed(&self, tentative_until_epoch: u64) -> bool {
+        self.confirmed_epoch >= tentative_until_epoch
+    }
+
+    /// Check whether any predictions are currently in a tentative (hidden) state.
+    ///
+    /// Returns true if the confirmed epoch is behind the prediction epoch,
+    /// meaning some recent predictions are not yet visible.
+    pub fn has_tentative_predictions(&self) -> bool {
+        self.confirmed_epoch < self.prediction_epoch
+    }
+
+    /// Create an EpochTracker with specific epoch values.
+    ///
+    /// Used for testing overflow/boundary conditions.
+    #[cfg(test)]
+    pub fn with_epochs(prediction_epoch: u64, confirmed_epoch: u64) -> Self {
+        Self {
+            prediction_epoch,
+            confirmed_epoch,
+        }
+    }
+
+    /// Reset both epochs to zero. Called on full engine reset (paste, resize, etc.).
+    pub fn reset(&mut self) {
+        self.prediction_epoch = 0;
+        self.confirmed_epoch = 0;
+    }
+
+    /// Kill predictions from the given epoch forward.
+    ///
+    /// Called when a misprediction is detected on a tentative cell. Advances
+    /// the prediction epoch so all predictions tagged >= the kill point are
+    /// considered stale. Returns the new prediction epoch.
+    pub fn kill_epoch(&mut self, from_epoch: u64) -> u64 {
+        if from_epoch <= self.prediction_epoch {
+            // Move prediction epoch past all killed predictions
+            self.prediction_epoch = self.prediction_epoch.saturating_add(1);
+            // Align confirmed to match so we don't leave a gap that can never close
+            self.confirmed_epoch = self.prediction_epoch;
+        }
+        self.prediction_epoch
+    }
+}
+
+impl Default for EpochTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tracker_has_zero_epochs() {
+        let tracker = EpochTracker::new();
+        assert_eq!(tracker.prediction_epoch(), 0);
+        assert_eq!(tracker.confirmed_epoch(), 0);
+    }
+
+    #[test]
+    fn become_tentative_increments_prediction_epoch() {
+        let mut tracker = EpochTracker::new();
+        tracker.become_tentative();
+        assert_eq!(tracker.prediction_epoch(), 1);
+        assert_eq!(tracker.confirmed_epoch(), 0);
+    }
+
+    #[test]
+    fn is_confirmed_at_epoch_zero_always_true() {
+        let tracker = EpochTracker::new();
+        // A prediction tagged with epoch 0 is visible immediately since confirmed == 0
+        assert!(tracker.is_confirmed(0));
+    }
+
+    #[test]
+    fn prediction_after_tentative_not_confirmed() {
+        let mut tracker = EpochTracker::new();
+        tracker.become_tentative();
+        // A prediction tagged with the new epoch (1) is not yet confirmed
+        assert!(!tracker.is_confirmed(1));
+        assert!(tracker.has_tentative_predictions());
+    }
+
+    #[test]
+    fn advance_confirmed_makes_tentative_visible() {
+        let mut tracker = EpochTracker::new();
+        tracker.become_tentative();
+        tracker.advance_confirmed();
+        assert!(tracker.is_confirmed(1));
+        assert!(!tracker.has_tentative_predictions());
+    }
+
+    #[test]
+    fn confirmed_cannot_exceed_prediction_epoch() {
+        let mut tracker = EpochTracker::new();
+        // Advance confirmed without any predictions — should stay at 0
+        tracker.advance_confirmed();
+        assert_eq!(tracker.confirmed_epoch(), 0);
+    }
+
+    #[test]
+    fn reset_clears_both_epochs() {
+        let mut tracker = EpochTracker::new();
+        tracker.become_tentative();
+        tracker.become_tentative();
+        tracker.advance_confirmed();
+        tracker.reset();
+        assert_eq!(tracker.prediction_epoch(), 0);
+        assert_eq!(tracker.confirmed_epoch(), 0);
+    }
+
+    #[test]
+    fn kill_epoch_advances_past_stale_predictions() {
+        let mut tracker = EpochTracker::new();
+        tracker.become_tentative(); // prediction_epoch = 1
+        tracker.become_tentative(); // prediction_epoch = 2
+        let new_epoch = tracker.kill_epoch(1);
+        // After kill, prediction epoch is higher and confirmed catches up
+        assert!(new_epoch > 2);
+        assert_eq!(tracker.confirmed_epoch(), tracker.prediction_epoch());
+    }
+
+    #[test]
+    fn saturating_add_prevents_overflow() {
+        let mut tracker = EpochTracker {
+            prediction_epoch: u64::MAX,
+            confirmed_epoch: u64::MAX,
+        };
+        // Should not panic — saturating_add stops at MAX
+        tracker.become_tentative();
+        assert_eq!(tracker.prediction_epoch(), u64::MAX);
+    }
+}

--- a/src/prediction/input.rs
+++ b/src/prediction/input.rs
@@ -1,0 +1,324 @@
+//! Input classification for the Mosh-style prediction engine.
+//!
+//! This module classifies keystrokes into three categories that determine
+//! what the prediction engine will do:
+//!
+//! - `Predictable(char)` — printable ASCII or cursor-movement arrow keys.
+//!   The engine will speculatively insert the character or move the cursor.
+//!
+//! - `Uncertain` — Ctrl+anything, CR, ESC, backspace, and any non-ASCII input.
+//!   The engine calls `become_tentative()`, hiding subsequent predictions until
+//!   the server confirms the resulting state.
+//!
+//! - `Bulk` — paste or other large byte sequences (>100 bytes).
+//!   The engine calls `reset()`, wiping all predictions entirely.
+//!
+//! - `Backspace` — a special case of Uncertain with defined cursor behavior:
+//!   the cursor prediction moves one column left and the prediction buffer
+//!   is trimmed accordingly.
+//!
+//! - `ArrowLeft` / `ArrowRight` — cursor movement without cell-content prediction.
+//!
+//! ## Design note
+//!
+//! `classify` is a pure function — it takes a `KeyEvent` and returns an
+//! `InputClass` with no side effects. All state mutation happens in
+//! `PredictionEngine` after classification.
+
+/// A key event fed into the prediction engine.
+///
+/// This is a simplified representation: we only need to know what bytes
+/// will be sent to the PTY, and whether Ctrl is held.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyEvent {
+    /// The bytes that will be sent to the PTY for this key press.
+    /// For printable ASCII, this is a single byte. For escape sequences,
+    /// this is the full sequence (e.g., `[27, b'[', b'D']` for left arrow).
+    pub bytes: Vec<u8>,
+
+    /// True if the Ctrl modifier was held when this key was pressed.
+    pub ctrl_held: bool,
+}
+
+impl KeyEvent {
+    /// Create a KeyEvent from a single printable ASCII character.
+    pub fn printable(ch: char) -> Self {
+        debug_assert!(ch.is_ascii() && ch as u8 >= 0x20 && ch as u8 <= 0x7e);
+        Self {
+            bytes: vec![ch as u8],
+            ctrl_held: false,
+        }
+    }
+
+    /// Create a KeyEvent from raw bytes (e.g., an escape sequence).
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            ctrl_held: false,
+        }
+    }
+
+    /// Create a Ctrl+key event.
+    pub fn ctrl(ch: char) -> Self {
+        let ctrl_byte = (ch.to_ascii_uppercase() as u8).wrapping_sub(b'@');
+        Self {
+            bytes: vec![ctrl_byte],
+            ctrl_held: true,
+        }
+    }
+
+    /// Create a backspace event (sends 0x7f, DEL).
+    pub fn backspace() -> Self {
+        Self {
+            bytes: vec![0x7f],
+            ctrl_held: false,
+        }
+    }
+
+    /// Create a carriage return event.
+    pub fn carriage_return() -> Self {
+        Self {
+            bytes: vec![0x0d],
+            ctrl_held: false,
+        }
+    }
+
+    /// Create a left-arrow key event (CSI D).
+    pub fn arrow_left() -> Self {
+        Self {
+            bytes: vec![0x1b, b'[', b'D'],
+            ctrl_held: false,
+        }
+    }
+
+    /// Create a right-arrow key event (CSI C).
+    pub fn arrow_right() -> Self {
+        Self {
+            bytes: vec![0x1b, b'[', b'C'],
+            ctrl_held: false,
+        }
+    }
+
+    /// Create a bulk paste event (>100 bytes).
+    pub fn bulk_paste(bytes: Vec<u8>) -> Self {
+        debug_assert!(bytes.len() > 100);
+        Self {
+            bytes,
+            ctrl_held: false,
+        }
+    }
+}
+
+/// The classification result for a single keystroke.
+///
+/// This is the output of `classify()` — a pure description of what the
+/// prediction engine should do, without any mutation having occurred.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputClass {
+    /// A printable ASCII character that can be speculatively inserted.
+    ///
+    /// The character is in the range 0x20–0x7e (space through tilde).
+    Predictable(char),
+
+    /// Left arrow key (CSI D) — move cursor prediction one column left.
+    ArrowLeft,
+
+    /// Right arrow key (CSI C) — move cursor prediction one column right.
+    ArrowRight,
+
+    /// Backspace (DEL, 0x7f) — move cursor prediction one column left
+    /// and trim the last predicted character.
+    Backspace,
+
+    /// An uncertain input that may change terminal state in ways we cannot predict.
+    ///
+    /// Triggers `become_tentative()` — new predictions will be hidden until
+    /// the server confirms the resulting state.
+    Uncertain,
+
+    /// A bulk paste (>100 bytes).
+    ///
+    /// Triggers a full `reset()` — all predictions are wiped.
+    Bulk,
+}
+
+/// Classify a key event into an `InputClass`.
+///
+/// This is a pure function: no state is read or mutated.
+///
+/// Classification logic (in priority order):
+/// 1. Bulk paste (>100 bytes) → `Bulk`
+/// 2. Left arrow CSI D → `ArrowLeft`
+/// 3. Right arrow CSI C → `ArrowRight`
+/// 4. Backspace (0x7f) → `Backspace`
+/// 5. Carriage return (0x0d) → `Uncertain`
+/// 6. ESC or any escape sequence → `Uncertain`
+/// 7. Ctrl held → `Uncertain`
+/// 8. Single printable ASCII (0x20–0x7e) → `Predictable(char)`
+/// 9. Everything else → `Uncertain`
+pub fn classify(key: &KeyEvent) -> InputClass {
+    // Rule 1: bulk paste — full reset
+    if key.bytes.len() > 100 {
+        return InputClass::Bulk;
+    }
+
+    // Rule 2/3: arrow key escape sequences
+    // CSI D = [ESC, '[', 'D'] = left arrow
+    // CSI C = [ESC, '[', 'C'] = right arrow
+    if key.bytes == [0x1b, b'[', b'D'] {
+        return InputClass::ArrowLeft;
+    }
+    if key.bytes == [0x1b, b'[', b'C'] {
+        return InputClass::ArrowRight;
+    }
+
+    // Rule 4: backspace (DEL)
+    if key.bytes == [0x7f] {
+        return InputClass::Backspace;
+    }
+
+    // Rule 5: carriage return
+    if key.bytes == [0x0d] || key.bytes == [b'\n'] {
+        return InputClass::Uncertain;
+    }
+
+    // Rule 6: any escape sequence (starts with 0x1b)
+    if key.bytes.first() == Some(&0x1b) {
+        return InputClass::Uncertain;
+    }
+
+    // Rule 7: ctrl modifier
+    if key.ctrl_held {
+        return InputClass::Uncertain;
+    }
+
+    // Rule 8: single printable ASCII
+    if key.bytes.len() == 1 {
+        let byte = key.bytes[0];
+        if byte >= 0x20 && byte <= 0x7e {
+            return InputClass::Predictable(byte as char);
+        }
+
+        // Control characters without Ctrl flag (e.g., raw 0x01)
+        return InputClass::Uncertain;
+    }
+
+    // Rule 9: multi-byte non-ASCII (e.g., UTF-8 encoded Unicode)
+    // We do not attempt to predict wide characters, emoji, or CJK input.
+    InputClass::Uncertain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn printable_ascii_is_predictable() {
+        let event = KeyEvent::printable('a');
+        assert_eq!(classify(&event), InputClass::Predictable('a'));
+    }
+
+    #[test]
+    fn space_is_predictable() {
+        let event = KeyEvent::printable(' ');
+        assert_eq!(classify(&event), InputClass::Predictable(' '));
+    }
+
+    #[test]
+    fn tilde_is_predictable() {
+        // 0x7e is the highest printable ASCII char
+        let event = KeyEvent {
+            bytes: vec![0x7e],
+            ctrl_held: false,
+        };
+        assert_eq!(classify(&event), InputClass::Predictable('~'));
+    }
+
+    #[test]
+    fn backspace_classified_correctly() {
+        let event = KeyEvent::backspace();
+        assert_eq!(classify(&event), InputClass::Backspace);
+    }
+
+    #[test]
+    fn carriage_return_is_uncertain() {
+        let event = KeyEvent::carriage_return();
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn ctrl_c_is_uncertain() {
+        let event = KeyEvent::ctrl('C');
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn ctrl_u_is_uncertain() {
+        let event = KeyEvent::ctrl('U');
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn left_arrow_classified() {
+        let event = KeyEvent::arrow_left();
+        assert_eq!(classify(&event), InputClass::ArrowLeft);
+    }
+
+    #[test]
+    fn right_arrow_classified() {
+        let event = KeyEvent::arrow_right();
+        assert_eq!(classify(&event), InputClass::ArrowRight);
+    }
+
+    #[test]
+    fn escape_alone_is_uncertain() {
+        let event = KeyEvent::from_bytes(vec![0x1b]);
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn escape_sequence_other_than_arrows_is_uncertain() {
+        // CSI A = up arrow
+        let event = KeyEvent::from_bytes(vec![0x1b, b'[', b'A']);
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn bulk_paste_classified() {
+        let bytes = vec![b'a'; 101];
+        let event = KeyEvent::bulk_paste(bytes);
+        assert_eq!(classify(&event), InputClass::Bulk);
+    }
+
+    #[test]
+    fn exactly_100_bytes_not_bulk() {
+        // 100 bytes is not > 100, so it is not Bulk
+        let bytes = vec![b'a'; 100];
+        let event = KeyEvent::from_bytes(bytes);
+        // 100 bytes is multi-byte non-ASCII-single-char, so Uncertain
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn utf8_multibyte_is_uncertain() {
+        // UTF-8 for '©' is [0xC2, 0xA9]
+        let event = KeyEvent::from_bytes(vec![0xC2, 0xA9]);
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn raw_control_byte_without_ctrl_flag_is_uncertain() {
+        // 0x01 = Ctrl+A but sent without the flag — still uncertain
+        let event = KeyEvent {
+            bytes: vec![0x01],
+            ctrl_held: false,
+        };
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+
+    #[test]
+    fn newline_is_uncertain() {
+        let event = KeyEvent::from_bytes(vec![b'\n']);
+        assert_eq!(classify(&event), InputClass::Uncertain);
+    }
+}

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -1,0 +1,457 @@
+//! Mosh-style local keystroke prediction for bisque-computer.
+//!
+//! This module implements speculative local echo — the same algorithm used by
+//! Mosh — to eliminate perceived latency on high-RTT connections. When a user
+//! types a character, the prediction engine immediately renders it locally
+//! without waiting for the server to echo it back. If the server disagrees,
+//! the prediction is silently discarded.
+//!
+//! ## Architecture
+//!
+//! ```text
+//!  KeyEvent ──► process_input()
+//!                     │
+//!                     ▼
+//!              classify (input.rs)
+//!                     │
+//!            ┌────────┼────────────┐
+//!            │        │            │
+//!         Predictable Uncertain  Bulk/Backspace/Arrow
+//!            │        │
+//!         insert     become_tentative()
+//!         into        │
+//!         overlay     (new predictions hidden until
+//!         (overlay.rs) server confirms)
+//!
+//!  Server bytes ──► process_server_output()
+//!                         │
+//!                    compare to overlay
+//!                    ┌────┴─────────┐
+//!                  Match         Mismatch
+//!                    │               │
+//!             advance_confirmed()  kill_epoch() / reset()
+//! ```
+//!
+//! ## RTT gating
+//!
+//! The engine is inactive below 20ms RTT (predictions never shown). Between
+//! 20ms and 80ms, predictions are shown without underline. Above 80ms,
+//! predictions are underlined to indicate uncertainty.
+//!
+//! ## Integration
+//!
+//! See `INTEGRATION.md` in this module directory for detailed wiring instructions.
+
+pub mod epoch;
+pub mod input;
+pub mod overlay;
+
+#[cfg(test)]
+mod tests;
+
+pub use epoch::EpochTracker;
+pub use input::{InputClass, KeyEvent, classify};
+pub use overlay::{FrameOverlay, OverlayCell, PredictedCursor};
+
+/// RTT threshold below which predictions are suppressed entirely.
+const RTT_THRESHOLD_LOW_MS: u32 = 20;
+
+/// RTT threshold above which predictions are displayed with underline.
+const RTT_THRESHOLD_HIGH_MS: u32 = 80;
+
+/// Hysteresis threshold: once predictions were active, keep them active
+/// until RTT drops below this value (prevents flicker near the boundary).
+const RTT_HYSTERESIS_MS: u32 = 20;
+
+/// Byte value for DEL / backspace.
+const BACKSPACE_BYTE: u8 = 0x7f;
+
+/// The prediction engine for Mosh-style local keystroke prediction.
+///
+/// This struct owns all mutable prediction state. It exposes a small,
+/// pure-ish API:
+/// - `process_input()` — feed a keystroke, get back an optional overlay action
+/// - `process_server_output()` — feed confirmed server bytes to advance epochs
+/// - `overlay()` — the current overlay to paint on top of confirmed state
+/// - `set_rtt()` — update RTT estimate for activation gating
+/// - `reset()` — wipe all state (on paste, resize, etc.)
+///
+/// The engine does NOT mutate `alacritty_terminal::Term`. It maintains its
+/// own separate cursor position and cell predictions.
+pub struct PredictionEngine {
+    /// The epoch tracker — core of the confirmation model.
+    epochs: EpochTracker,
+
+    /// The overlay grid — sparse map of predicted cells.
+    overlay: FrameOverlay,
+
+    /// Current predicted cursor column (0-indexed).
+    cursor_col: u16,
+
+    /// Current predicted cursor row (0-indexed).
+    cursor_row: u16,
+
+    /// The confirmed cursor column — updated when server output is processed.
+    confirmed_cursor_col: u16,
+
+    /// The confirmed cursor row — updated when server output is processed.
+    confirmed_cursor_row: u16,
+
+    /// Terminal width (columns). Used for right-edge clamping.
+    terminal_cols: u16,
+
+    /// Terminal height (rows). Used for bottom-edge clamping.
+    terminal_rows: u16,
+
+    /// Smoothed RTT estimate in milliseconds.
+    rtt_ms: u32,
+
+    /// Whether predictions are currently active (RTT-gated).
+    ///
+    /// Uses hysteresis: activates when RTT >= RTT_THRESHOLD_LOW_MS,
+    /// deactivates only when RTT < RTT_HYSTERESIS_MS AND no predictions pending.
+    predictions_active: bool,
+
+    /// Buffer of predicted bytes in order, for comparing against server output.
+    ///
+    /// Each entry is the byte we predicted at that position. When the server
+    /// sends output, we compare it character by character against this buffer.
+    predicted_bytes: Vec<u8>,
+}
+
+/// The action taken by the prediction engine after processing input.
+///
+/// Returned by `process_input()` for inspection in tests and callers that
+/// want to know what the engine did without inspecting the overlay directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PredictionAction {
+    /// A character was predicted and added to the overlay.
+    CharInserted { col: u16, row: u16, ch: char },
+
+    /// The cursor prediction was moved left (backspace or left arrow).
+    CursorMovedLeft,
+
+    /// The cursor prediction was moved right (right arrow).
+    CursorMovedRight,
+
+    /// The engine became tentative — predictions hidden until server confirms.
+    BecameTentative,
+
+    /// The engine was fully reset (bulk paste or overflow).
+    Reset,
+
+    /// Predictions are inactive at current RTT — no action taken.
+    Inactive,
+}
+
+impl PredictionEngine {
+    /// Create a new prediction engine.
+    ///
+    /// The engine starts inactive (RTT is 0ms). Call `set_rtt()` to enable it.
+    ///
+    /// `terminal_cols` and `terminal_rows` define the grid dimensions for
+    /// cursor clamping. Call `set_terminal_size()` on resize.
+    pub fn new(terminal_cols: u16, terminal_rows: u16) -> Self {
+        Self {
+            epochs: EpochTracker::new(),
+            overlay: FrameOverlay::new(),
+            cursor_col: 0,
+            cursor_row: 0,
+            confirmed_cursor_col: 0,
+            confirmed_cursor_row: 0,
+            terminal_cols,
+            terminal_rows,
+            rtt_ms: 0,
+            predictions_active: false,
+            predicted_bytes: Vec::new(),
+        }
+    }
+
+    /// Update the RTT estimate and adjust prediction activation accordingly.
+    ///
+    /// - RTT < 20ms with no pending predictions → deactivate
+    /// - RTT >= 20ms → activate
+    pub fn set_rtt(&mut self, rtt_ms: u32) {
+        self.rtt_ms = rtt_ms;
+
+        if rtt_ms >= RTT_THRESHOLD_LOW_MS {
+            self.predictions_active = true;
+        } else if rtt_ms < RTT_HYSTERESIS_MS && !self.overlay.has_cells() {
+            // Only deactivate if there are no pending predictions to avoid
+            // flickering during a brief RTT dip
+            self.predictions_active = false;
+        }
+    }
+
+    /// Whether predictions are currently underlined (RTT > 80ms).
+    pub fn is_flagging(&self) -> bool {
+        self.rtt_ms > RTT_THRESHOLD_HIGH_MS
+    }
+
+    /// Whether the prediction engine is currently active.
+    pub fn is_active(&self) -> bool {
+        self.predictions_active
+    }
+
+    /// Update the terminal dimensions. Clamps cursor predictions to the new size.
+    pub fn set_terminal_size(&mut self, cols: u16, rows: u16) {
+        self.terminal_cols = cols;
+        self.terminal_rows = rows;
+        // A resize invalidates all predictions — the server will redraw everything
+        self.reset();
+    }
+
+    /// Update the confirmed cursor position from the server's last known state.
+    ///
+    /// Call this after `process_server_output()` has been called and the
+    /// `alacritty_terminal::Term` has been updated.
+    pub fn sync_confirmed_cursor(&mut self, col: u16, row: u16) {
+        self.confirmed_cursor_col = col;
+        self.confirmed_cursor_row = row;
+        // If no predictions are pending, snap predicted cursor to confirmed
+        if self.overlay.is_empty() {
+            self.cursor_col = col;
+            self.cursor_row = row;
+        }
+    }
+
+    /// Process a keystroke and update the overlay.
+    ///
+    /// Returns a `PredictionAction` describing what the engine did. The caller
+    /// can also call `overlay()` afterwards to get the full current overlay.
+    ///
+    /// Returns `PredictionAction::Inactive` if RTT is below the activation
+    /// threshold and predictions are not currently active.
+    pub fn process_input(&mut self, key: &KeyEvent) -> PredictionAction {
+        let class = classify(key);
+
+        // Bulk paste always resets, regardless of active state
+        if class == InputClass::Bulk {
+            self.reset();
+            return PredictionAction::Reset;
+        }
+
+        if !self.predictions_active {
+            // Still track uncertain state even when inactive, so that if
+            // predictions become active mid-session, they start correctly
+            if class == InputClass::Uncertain {
+                self.epochs.become_tentative();
+            }
+            return PredictionAction::Inactive;
+        }
+
+        match class {
+            InputClass::Predictable(ch) => self.predict_char(ch),
+            InputClass::Backspace => self.predict_backspace(),
+            InputClass::ArrowLeft => self.predict_arrow_left(),
+            InputClass::ArrowRight => self.predict_arrow_right(),
+            InputClass::Uncertain => {
+                self.epochs.become_tentative();
+                PredictionAction::BecameTentative
+            }
+            InputClass::Bulk => unreachable!("handled above"),
+        }
+    }
+
+    /// Feed confirmed server output bytes into the engine.
+    ///
+    /// This compares server output against our pending predictions:
+    /// - Matching bytes: remove from the prediction buffer; cells are confirmed
+    ///   and removed from the overlay. If there are tentative predictions, advance
+    ///   `confirmed_epoch` so they become visible.
+    /// - Mismatch: kill the epoch and wipe all pending predictions from the overlay.
+    ///
+    /// Control sequences in the server output are ignored during comparison — we
+    /// only compare printable bytes (0x20–0x7e).
+    pub fn process_server_output(&mut self, bytes: &[u8]) {
+        if self.predicted_bytes.is_empty() {
+            return;
+        }
+
+        // Collect only the printable bytes from the server output for comparison.
+        let printable_server_bytes: Vec<u8> = bytes
+            .iter()
+            .copied()
+            .filter(|&b| b >= 0x20 && b <= 0x7e)
+            .collect();
+
+        if printable_server_bytes.is_empty() {
+            return;
+        }
+
+        // Compare against predicted bytes, one at a time.
+        let mut matched = 0;
+        let mut mismatch = false;
+
+        for &server_byte in &printable_server_bytes {
+            if matched >= self.predicted_bytes.len() {
+                break;
+            }
+            if self.predicted_bytes[matched] == server_byte {
+                matched += 1;
+            } else {
+                mismatch = true;
+                break;
+            }
+        }
+
+        if mismatch {
+            // Server output disagrees with our prediction — wipe all predictions.
+            let stale_epoch = self.epochs.prediction_epoch();
+            self.epochs.kill_epoch(stale_epoch);
+            self.overlay.clear();
+            self.predicted_bytes.clear();
+            // Snap predicted cursor back to confirmed position
+            self.cursor_col = self.confirmed_cursor_col;
+            self.cursor_row = self.confirmed_cursor_row;
+        } else if matched > 0 {
+            // Server confirmed `matched` bytes of predictions.
+            // Remove confirmed cells from the overlay (server is the truth now).
+            // We know predictions were placed starting from the confirmed cursor,
+            // advancing one column per predicted char.
+            let start_col = self.confirmed_cursor_col;
+            for i in 0..matched as u16 {
+                self.overlay.remove(start_col + i, self.confirmed_cursor_row);
+            }
+
+            // Remove from the prediction buffer.
+            self.predicted_bytes.drain(..matched);
+
+            // Advance confirmed_epoch for each tentative prediction confirmed.
+            // This makes any tentative cells visible (those typed after an uncertain input).
+            for _ in 0..matched {
+                self.epochs.advance_confirmed();
+            }
+        }
+    }
+
+    /// Get the current overlay to paint on top of the confirmed terminal state.
+    ///
+    /// The overlay contains all predicted cells. Callers should use
+    /// `overlay.visible_cells(confirmed_epoch)` or call `overlay()` and then
+    /// iterate with the engine's `confirmed_epoch()`.
+    pub fn overlay(&self) -> &FrameOverlay {
+        &self.overlay
+    }
+
+    /// The current confirmed epoch — pass this to `overlay.visible_cells()`.
+    pub fn confirmed_epoch(&self) -> u64 {
+        self.epochs.confirmed_epoch()
+    }
+
+    /// The current prediction epoch.
+    pub fn prediction_epoch(&self) -> u64 {
+        self.epochs.prediction_epoch()
+    }
+
+    /// The predicted cursor position.
+    ///
+    /// Returns `(col, row)`. If no cursor prediction is active, returns
+    /// `(confirmed_cursor_col, confirmed_cursor_row)`.
+    pub fn predicted_cursor(&self) -> (u16, u16) {
+        if let Some(cursor) = self.overlay.cursor(self.epochs.confirmed_epoch()) {
+            (cursor.col, cursor.row)
+        } else {
+            (self.confirmed_cursor_col, self.confirmed_cursor_row)
+        }
+    }
+
+    /// Reset all prediction state.
+    ///
+    /// Called on paste (>100 bytes), terminal resize, or any other event
+    /// that makes all current predictions invalid.
+    pub fn reset(&mut self) {
+        self.epochs.reset();
+        self.overlay.clear();
+        self.predicted_bytes.clear();
+        self.cursor_col = self.confirmed_cursor_col;
+        self.cursor_row = self.confirmed_cursor_row;
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    /// Predict the insertion of a printable character at the current cursor.
+    fn predict_char(&mut self, ch: char) -> PredictionAction {
+        let col = self.cursor_col;
+        let row = self.cursor_row;
+        let epoch = self.epochs.prediction_epoch();
+        let underlined = self.is_flagging();
+
+        let cell = OverlayCell::new(ch, underlined, epoch);
+        self.overlay.insert(col, row, cell);
+
+        // Update the cursor prediction
+        let new_col = self.cursor_col.saturating_add(1).min(self.terminal_cols.saturating_sub(1));
+
+        // At the right edge of the terminal, become tentative — we don't predict
+        // line wrap behavior (same conservative stance as Mosh)
+        if self.cursor_col >= self.terminal_cols.saturating_sub(1) {
+            self.epochs.become_tentative();
+        }
+
+        self.cursor_col = new_col;
+
+        // Update the cursor overlay
+        let cursor_epoch = self.epochs.prediction_epoch();
+        self.overlay.set_cursor(PredictedCursor::new(self.cursor_col, self.cursor_row, cursor_epoch));
+
+        // Track the predicted byte for server comparison
+        self.predicted_bytes.push(ch as u8);
+
+        PredictionAction::CharInserted { col, row, ch }
+    }
+
+    /// Predict a backspace — remove the last predicted character.
+    fn predict_backspace(&mut self) -> PredictionAction {
+        // Become tentative for the backspace itself — the server's response
+        // may differ (e.g., bash may clear more than one char with readline bindings)
+        self.epochs.become_tentative();
+
+        // Remove the last predicted cell
+        self.overlay.pop_last_prediction();
+
+        // Remove the last predicted byte
+        self.predicted_bytes.pop();
+
+        // Move cursor prediction left (don't go past column 0)
+        self.cursor_col = self.cursor_col.saturating_sub(1);
+
+        // Cursor position is shown at confirmed_epoch (immediately visible).
+        // Cell content predictions use prediction_epoch (gated until confirmed),
+        // but cursor position alone is low-risk to show immediately.
+        let cursor_epoch = self.epochs.confirmed_epoch();
+        self.overlay.set_cursor(PredictedCursor::new(self.cursor_col, self.cursor_row, cursor_epoch));
+
+        PredictionAction::CursorMovedLeft
+    }
+
+    /// Predict left-arrow cursor movement.
+    fn predict_arrow_left(&mut self) -> PredictionAction {
+        self.epochs.become_tentative();
+        self.cursor_col = self.cursor_col.saturating_sub(1);
+
+        // Cursor position shown immediately (confirmed_epoch), not gated on tentative.
+        let cursor_epoch = self.epochs.confirmed_epoch();
+        self.overlay.set_cursor(PredictedCursor::new(self.cursor_col, self.cursor_row, cursor_epoch));
+
+        PredictionAction::CursorMovedLeft
+    }
+
+    /// Predict right-arrow cursor movement.
+    fn predict_arrow_right(&mut self) -> PredictionAction {
+        self.epochs.become_tentative();
+        self.cursor_col = self.cursor_col.saturating_add(1).min(self.terminal_cols.saturating_sub(1));
+
+        // Cursor position shown immediately (confirmed_epoch), not gated on tentative.
+        let cursor_epoch = self.epochs.confirmed_epoch();
+        self.overlay.set_cursor(PredictedCursor::new(self.cursor_col, self.cursor_row, cursor_epoch));
+
+        PredictionAction::CursorMovedRight
+    }
+}
+
+impl Default for PredictionEngine {
+    fn default() -> Self {
+        Self::new(80, 24)
+    }
+}

--- a/src/prediction/overlay.rs
+++ b/src/prediction/overlay.rs
@@ -1,0 +1,320 @@
+//! The frame overlay — a sparse grid of predicted cells painted over the
+//! confirmed terminal state.
+//!
+//! ## Design
+//!
+//! The overlay is a `HashMap<(u16, u16), OverlayCell>` keyed by `(col, row)`.
+//! This is intentionally sparse: most cells are confirmed server state. We
+//! only store cells where the prediction engine has made a speculative change.
+//!
+//! The overlay also tracks the predicted cursor position separately from the
+//! cell content, since cursor-only prediction (without cell content prediction)
+//! is the safest mode of operation.
+//!
+//! ## Epoch filtering
+//!
+//! `OverlayCell` stores the `tentative_until_epoch` at which it was created.
+//! The `FrameOverlay::visible_cells(confirmed_epoch)` iterator only yields
+//! cells whose `tentative_until_epoch <= confirmed_epoch` — i.e., cells whose
+//! epoch has been confirmed by server output.
+//!
+//! This means the overlay can contain many cells that are currently invisible.
+//! They become visible as the server confirms output, without requiring any
+//! explicit "promotion" step.
+
+use std::collections::HashMap;
+
+/// A single predicted cell overlay entry.
+///
+/// Stores the predicted character, its display attributes, and the epoch
+/// at which it was created (used to gate visibility).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverlayCell {
+    /// The predicted character to display.
+    pub ch: char,
+
+    /// Whether to underline this prediction (set when RTT > 80ms).
+    ///
+    /// Underlining signals to the user that this character is speculative.
+    /// It matches Mosh's "flagging" behavior.
+    pub underlined: bool,
+
+    /// The epoch at which this prediction was created.
+    ///
+    /// This cell is only shown when `confirmed_epoch >= tentative_until_epoch`.
+    pub tentative_until_epoch: u64,
+}
+
+impl OverlayCell {
+    /// Create a new overlay cell.
+    pub fn new(ch: char, underlined: bool, tentative_until_epoch: u64) -> Self {
+        Self {
+            ch,
+            underlined,
+            tentative_until_epoch,
+        }
+    }
+
+    /// Whether this cell should be shown given the current confirmed epoch.
+    pub fn is_visible(&self, confirmed_epoch: u64) -> bool {
+        confirmed_epoch >= self.tentative_until_epoch
+    }
+}
+
+/// The predicted cursor position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PredictedCursor {
+    /// Column (0-indexed, from left).
+    pub col: u16,
+
+    /// Row (0-indexed, from top).
+    pub row: u16,
+
+    /// The epoch at which this cursor prediction was created.
+    pub tentative_until_epoch: u64,
+}
+
+impl PredictedCursor {
+    pub fn new(col: u16, row: u16, tentative_until_epoch: u64) -> Self {
+        Self {
+            col,
+            row,
+            tentative_until_epoch,
+        }
+    }
+
+    pub fn is_visible(&self, confirmed_epoch: u64) -> bool {
+        confirmed_epoch >= self.tentative_until_epoch
+    }
+}
+
+/// A sparse overlay grid to be painted on top of the confirmed terminal state.
+///
+/// This struct owns all predicted cell state. It does not modify the underlying
+/// `alacritty_terminal::Term` — it only describes what to paint on top.
+#[derive(Debug, Clone)]
+pub struct FrameOverlay {
+    /// Sparse map of (col, row) → predicted cell.
+    cells: HashMap<(u16, u16), OverlayCell>,
+
+    /// The predicted cursor position, if any.
+    cursor: Option<PredictedCursor>,
+
+    /// Ordered list of predicted positions for backspace support.
+    ///
+    /// When the user types characters and then backspaces, we need to know
+    /// which cell to remove. This stack tracks the sequence of predicted
+    /// cursor positions in insertion order.
+    prediction_stack: Vec<(u16, u16)>,
+}
+
+impl FrameOverlay {
+    /// Create a new empty overlay.
+    pub fn new() -> Self {
+        Self {
+            cells: HashMap::new(),
+            cursor: None,
+            prediction_stack: Vec::new(),
+        }
+    }
+
+    /// Insert a predicted cell at the given position.
+    ///
+    /// If a cell already exists at that position, it is replaced.
+    /// The position is also pushed onto the prediction stack for backspace support.
+    pub fn insert(&mut self, col: u16, row: u16, cell: OverlayCell) {
+        self.prediction_stack.push((col, row));
+        self.cells.insert((col, row), cell);
+    }
+
+    /// Remove the most recently predicted cell (backspace support).
+    ///
+    /// Returns the position of the removed cell, or `None` if the stack is empty.
+    pub fn pop_last_prediction(&mut self) -> Option<(u16, u16)> {
+        while let Some(pos) = self.prediction_stack.pop() {
+            if self.cells.remove(&pos).is_some() {
+                return Some(pos);
+            }
+            // Cell was already removed (e.g., cleared by epoch kill) — keep popping
+        }
+        None
+    }
+
+    /// Set the predicted cursor position.
+    pub fn set_cursor(&mut self, cursor: PredictedCursor) {
+        self.cursor = Some(cursor);
+    }
+
+    /// Get the predicted cursor position, if visible at the given confirmed epoch.
+    pub fn cursor(&self, confirmed_epoch: u64) -> Option<&PredictedCursor> {
+        self.cursor
+            .as_ref()
+            .filter(|c| c.is_visible(confirmed_epoch))
+    }
+
+    /// Returns true if the overlay has no cells and no cursor.
+    pub fn is_empty(&self) -> bool {
+        self.cells.is_empty() && self.cursor.is_none()
+    }
+
+    /// Returns true if there are any predicted cells (visible or not).
+    pub fn has_cells(&self) -> bool {
+        !self.cells.is_empty()
+    }
+
+    /// Iterate over all cells that are currently visible at the given confirmed epoch.
+    ///
+    /// Yields `((col, row), &OverlayCell)` tuples.
+    pub fn visible_cells(
+        &self,
+        confirmed_epoch: u64,
+    ) -> impl Iterator<Item = ((u16, u16), &OverlayCell)> {
+        self.cells
+            .iter()
+            .filter(move |(_, cell)| cell.is_visible(confirmed_epoch))
+            .map(|(pos, cell)| (*pos, cell))
+    }
+
+    /// Iterate over all cells regardless of epoch visibility.
+    ///
+    /// Useful for debugging and internal state inspection.
+    pub fn iter(&self) -> impl Iterator<Item = ((u16, u16), &OverlayCell)> {
+        self.cells.iter().map(|(pos, cell)| (*pos, cell))
+    }
+
+    /// Remove all cells whose `tentative_until_epoch > confirmed_epoch`.
+    ///
+    /// Called when a misprediction is detected and we need to cull stale
+    /// predictions that will never be confirmed.
+    pub fn cull_tentative(&mut self, confirmed_epoch: u64) {
+        self.cells
+            .retain(|_, cell| cell.tentative_until_epoch <= confirmed_epoch);
+        // Trim the prediction stack to only positions still in the map
+        self.prediction_stack
+            .retain(|pos| self.cells.contains_key(pos));
+    }
+
+    /// Remove a specific cell by position. Returns the removed cell if it existed.
+    pub fn remove(&mut self, col: u16, row: u16) -> Option<OverlayCell> {
+        self.cells.remove(&(col, row))
+    }
+
+    /// Get a cell at a position without removing it.
+    pub fn get(&self, col: u16, row: u16) -> Option<&OverlayCell> {
+        self.cells.get(&(col, row))
+    }
+
+    /// Clear all predicted cells and cursor. Equivalent to a full reset.
+    pub fn clear(&mut self) {
+        self.cells.clear();
+        self.cursor = None;
+        self.prediction_stack.clear();
+    }
+
+    /// The number of cells in the overlay (including invisible/tentative ones).
+    pub fn cell_count(&self) -> usize {
+        self.cells.len()
+    }
+}
+
+impl Default for FrameOverlay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(ch: char, epoch: u64) -> OverlayCell {
+        OverlayCell::new(ch, false, epoch)
+    }
+
+    #[test]
+    fn new_overlay_is_empty() {
+        let overlay = FrameOverlay::new();
+        assert!(overlay.is_empty());
+        assert_eq!(overlay.cell_count(), 0);
+    }
+
+    #[test]
+    fn insert_and_retrieve_cell() {
+        let mut overlay = FrameOverlay::new();
+        overlay.insert(5, 2, cell('a', 0));
+        assert_eq!(overlay.cell_count(), 1);
+        let c = overlay.get(5, 2).unwrap();
+        assert_eq!(c.ch, 'a');
+    }
+
+    #[test]
+    fn visible_cells_filters_by_confirmed_epoch() {
+        let mut overlay = FrameOverlay::new();
+        // epoch 0 cell — visible immediately
+        overlay.insert(0, 0, cell('a', 0));
+        // epoch 2 cell — only visible when confirmed >= 2
+        overlay.insert(1, 0, cell('b', 2));
+
+        let visible: Vec<_> = overlay.visible_cells(0).collect();
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].1.ch, 'a');
+
+        let visible: Vec<_> = overlay.visible_cells(2).collect();
+        assert_eq!(visible.len(), 2);
+    }
+
+    #[test]
+    fn pop_last_prediction_removes_most_recent() {
+        let mut overlay = FrameOverlay::new();
+        overlay.insert(0, 0, cell('a', 0));
+        overlay.insert(1, 0, cell('b', 0));
+        overlay.insert(2, 0, cell('c', 0));
+
+        let popped = overlay.pop_last_prediction();
+        assert_eq!(popped, Some((2, 0)));
+        assert_eq!(overlay.cell_count(), 2);
+    }
+
+    #[test]
+    fn cull_tentative_removes_future_epoch_cells() {
+        let mut overlay = FrameOverlay::new();
+        overlay.insert(0, 0, cell('a', 0)); // confirmed at epoch 0
+        overlay.insert(1, 0, cell('b', 5)); // tentative until epoch 5
+
+        overlay.cull_tentative(2); // confirmed_epoch = 2
+
+        // 'a' stays (0 <= 2), 'b' is removed (5 > 2)
+        assert_eq!(overlay.cell_count(), 1);
+        assert!(overlay.get(0, 0).is_some());
+        assert!(overlay.get(1, 0).is_none());
+    }
+
+    #[test]
+    fn clear_resets_all_state() {
+        let mut overlay = FrameOverlay::new();
+        overlay.insert(0, 0, cell('a', 0));
+        overlay.set_cursor(PredictedCursor::new(1, 0, 0));
+
+        overlay.clear();
+
+        assert!(overlay.is_empty());
+        assert!(overlay.cursor(0).is_none());
+    }
+
+    #[test]
+    fn cursor_visibility_gated_by_epoch() {
+        let mut overlay = FrameOverlay::new();
+        overlay.set_cursor(PredictedCursor::new(3, 1, 2));
+
+        // Not visible at epoch 1
+        assert!(overlay.cursor(1).is_none());
+        // Visible at epoch 2
+        assert!(overlay.cursor(2).is_some());
+    }
+
+    #[test]
+    fn overlay_cell_underlined_flag() {
+        let cell = OverlayCell::new('x', true, 0);
+        assert!(cell.underlined);
+    }
+}

--- a/src/prediction/tests.rs
+++ b/src/prediction/tests.rs
@@ -1,0 +1,855 @@
+//! Comprehensive unit tests for the Mosh-style prediction engine.
+//!
+//! Tests are organized by the behavior they verify:
+//!
+//! 1. Basic prediction (type char → overlay shows char at cursor)
+//! 2. Epoch confirmation (server echoes → confirmed_epoch advances)
+//! 3. Misprediction detection (server disagrees → prediction wiped)
+//! 4. Uncertain input gating (Ctrl+C → tentative, no new visible predictions)
+//! 5. Backspace prediction (trim last predicted char)
+//! 6. RTT gating (inactive <20ms, active ≥20ms, underlined >80ms)
+//! 7. Bulk paste reset (>100 bytes → full reset)
+//! 8. Cursor movement prediction (left/right arrows)
+//! 9. Epoch overflow edge cases (u64::MAX behavior)
+//! 10. Multi-character sequences and confirmation flow
+
+use super::{
+    InputClass, KeyEvent, PredictionAction, PredictionEngine,
+    classify,
+    epoch::EpochTracker,
+    overlay::{FrameOverlay, OverlayCell, PredictedCursor},
+};
+
+// ── Helper constructors ────────────────────────────────────────────────────────
+
+/// Build an engine with predictions active (RTT = 50ms).
+fn active_engine() -> PredictionEngine {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(50);
+    engine
+}
+
+/// Build an engine with flagging active (RTT = 100ms > 80ms threshold).
+fn flagging_engine() -> PredictionEngine {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(100);
+    engine
+}
+
+/// Count visible cells in the overlay at the engine's current confirmed epoch.
+fn visible_cell_count(engine: &PredictionEngine) -> usize {
+    engine
+        .overlay()
+        .visible_cells(engine.confirmed_epoch())
+        .count()
+}
+
+/// Get the visible character at a position, or None.
+fn visible_char_at(engine: &PredictionEngine, col: u16, row: u16) -> Option<char> {
+    engine
+        .overlay()
+        .visible_cells(engine.confirmed_epoch())
+        .find(|((c, r), _)| *c == col && *r == row)
+        .map(|(_, cell)| cell.ch)
+}
+
+// ── Section 1: Basic prediction ───────────────────────────────────────────────
+
+#[test]
+fn basic_prediction_type_a_shows_at_cursor() {
+    let mut engine = active_engine();
+    // Initial cursor is at (0, 0)
+    // Type 'a' — prediction should appear at col 0, row 0
+    let action = engine.process_input(&KeyEvent::printable('a'));
+
+    assert_eq!(
+        action,
+        PredictionAction::CharInserted {
+            col: 0,
+            row: 0,
+            ch: 'a'
+        }
+    );
+    assert_eq!(visible_char_at(&engine, 0, 0), Some('a'));
+    assert_eq!(visible_cell_count(&engine), 1);
+}
+
+#[test]
+fn typing_multiple_chars_advances_cursor() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+    engine.process_input(&KeyEvent::printable('c'));
+
+    // Three cells predicted at columns 0, 1, 2
+    assert_eq!(visible_char_at(&engine, 0, 0), Some('a'));
+    assert_eq!(visible_char_at(&engine, 1, 0), Some('b'));
+    assert_eq!(visible_char_at(&engine, 2, 0), Some('c'));
+
+    // Predicted cursor should now be at column 3
+    let (cursor_col, _cursor_row) = engine.predicted_cursor();
+    assert_eq!(cursor_col, 3);
+}
+
+#[test]
+fn prediction_cursor_moves_after_insert() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('x'));
+
+    let (col, row) = engine.predicted_cursor();
+    assert_eq!(col, 1);
+    assert_eq!(row, 0);
+}
+
+#[test]
+fn predictions_visible_at_epoch_zero() {
+    let mut engine = active_engine();
+    // At the start, confirmed_epoch = 0, prediction_epoch = 0.
+    // A prediction tagged with epoch 0 is immediately visible.
+    engine.process_input(&KeyEvent::printable('h'));
+    assert_eq!(visible_cell_count(&engine), 1);
+}
+
+// ── Section 2: Epoch confirmation ─────────────────────────────────────────────
+
+#[test]
+fn server_echo_removes_cell_from_overlay() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+
+    // Cell exists in overlay before echo
+    assert!(engine.overlay().get(0, 0).is_some());
+
+    engine.process_server_output(b"a");
+
+    // Server confirmation removes the cell from the overlay
+    assert!(
+        engine.overlay().get(0, 0).is_none(),
+        "Confirmed cell should be removed from overlay"
+    );
+}
+
+#[test]
+fn server_echo_of_tentative_prediction_advances_confirmed_epoch() {
+    let mut engine = active_engine();
+
+    // Create tentative predictions by typing Ctrl+C then chars
+    engine.process_input(&KeyEvent::ctrl('C')); // prediction_epoch = 1
+    engine.process_input(&KeyEvent::printable('a')); // tagged with epoch 1
+
+    let confirmed_before = engine.confirmed_epoch(); // = 0
+
+    // Server echoes the char — should advance confirmed_epoch
+    engine.process_server_output(b"a");
+
+    assert!(
+        engine.confirmed_epoch() > confirmed_before,
+        "confirmed_epoch should advance when tentative prediction is confirmed"
+    );
+}
+
+#[test]
+fn server_echo_of_non_tentative_does_not_change_confirmed_epoch() {
+    let mut engine = active_engine();
+    // No uncertain input → both epochs stay at 0
+    engine.process_input(&KeyEvent::printable('a'));
+
+    let confirmed_before = engine.confirmed_epoch(); // = 0
+    engine.process_server_output(b"a");
+
+    // Both epochs were 0, advance_confirmed is a no-op when confirmed == prediction
+    assert_eq!(engine.confirmed_epoch(), confirmed_before);
+}
+
+#[test]
+fn server_echo_of_multiple_predicted_chars_clears_overlay() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+
+    // Server echoes both characters
+    engine.process_server_output(b"ab");
+
+    // Confirmed cells removed from overlay
+    assert!(engine.overlay().get(0, 0).is_none());
+    assert!(engine.overlay().get(1, 0).is_none());
+}
+
+#[test]
+fn server_output_no_predictions_is_no_op() {
+    let mut engine = active_engine();
+    // No predictions made — process_server_output should not change anything
+    let before = engine.confirmed_epoch();
+    engine.process_server_output(b"anything");
+    assert_eq!(engine.confirmed_epoch(), before);
+}
+
+// ── Section 3: Misprediction detection ───────────────────────────────────────
+
+#[test]
+fn misprediction_wipes_overlay() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+
+    // Server sends a different character
+    engine.process_server_output(b"b");
+
+    // After misprediction, overlay should be empty
+    assert_eq!(engine.overlay().cell_count(), 0);
+}
+
+#[test]
+fn misprediction_resets_cursor_to_confirmed() {
+    let mut engine = active_engine();
+    engine.sync_confirmed_cursor(5, 2);
+    // Now type a character (moves predicted cursor to col 6)
+    engine.process_input(&KeyEvent::printable('z'));
+
+    // Server sends something different
+    engine.process_server_output(b"q");
+
+    // Cursor snaps back to confirmed position
+    let (col, row) = engine.predicted_cursor();
+    assert_eq!(col, 5);
+    assert_eq!(row, 2);
+}
+
+#[test]
+fn misprediction_kills_epoch() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+
+    let epoch_before = engine.prediction_epoch();
+    engine.process_server_output(b"b"); // mismatch
+
+    // After kill_epoch, prediction_epoch is higher
+    assert!(engine.prediction_epoch() > epoch_before);
+    // And confirmed_epoch has caught up (no permanent gap)
+    assert_eq!(engine.confirmed_epoch(), engine.prediction_epoch());
+}
+
+// ── Section 4: Uncertain input gating ────────────────────────────────────────
+
+#[test]
+fn ctrl_c_becomes_tentative() {
+    let mut engine = active_engine();
+    let epoch_before = engine.prediction_epoch();
+
+    let action = engine.process_input(&KeyEvent::ctrl('C'));
+
+    assert_eq!(action, PredictionAction::BecameTentative);
+    assert!(engine.prediction_epoch() > epoch_before);
+}
+
+#[test]
+fn predictions_after_ctrl_c_are_hidden_until_server_confirms() {
+    let mut engine = active_engine();
+
+    // Type 'a' (visible prediction, epoch 0)
+    engine.process_input(&KeyEvent::printable('a'));
+    assert_eq!(visible_cell_count(&engine), 1);
+
+    // Ctrl+C → prediction_epoch becomes 1, confirmed_epoch still 0
+    engine.process_input(&KeyEvent::ctrl('C'));
+
+    // Type 'b' → tagged with epoch 1, hidden since confirmed_epoch = 0 < 1
+    engine.process_input(&KeyEvent::printable('b'));
+
+    // 'a' is at epoch 0 (visible), 'b' is at epoch 1 (hidden)
+    let visible_chars: Vec<char> = engine
+        .overlay()
+        .visible_cells(engine.confirmed_epoch())
+        .map(|(_, cell)| cell.ch)
+        .collect();
+
+    // 'b' should be invisible since the epoch hasn't been confirmed
+    assert!(!visible_chars.contains(&'b'));
+}
+
+#[test]
+fn esc_key_becomes_tentative() {
+    let mut engine = active_engine();
+    let epoch_before = engine.prediction_epoch();
+
+    engine.process_input(&KeyEvent::from_bytes(vec![0x1b]));
+
+    assert!(engine.prediction_epoch() > epoch_before);
+}
+
+#[test]
+fn carriage_return_becomes_tentative() {
+    let mut engine = active_engine();
+    let epoch_before = engine.prediction_epoch();
+
+    let action = engine.process_input(&KeyEvent::carriage_return());
+
+    assert_eq!(action, PredictionAction::BecameTentative);
+    assert!(engine.prediction_epoch() > epoch_before);
+}
+
+#[test]
+fn no_new_visible_predictions_while_tentative() {
+    let mut engine = active_engine();
+
+    // Trigger tentative state via Ctrl+U
+    engine.process_input(&KeyEvent::ctrl('U'));
+    // confirmed_epoch < prediction_epoch means tentative predictions exist
+    assert!(engine.confirmed_epoch() < engine.prediction_epoch());
+
+    // Type characters in tentative state
+    engine.process_input(&KeyEvent::printable('x'));
+    engine.process_input(&KeyEvent::printable('y'));
+
+    // Those new cells are invisible (they are tagged with the tentative epoch)
+    let visible = visible_cell_count(&engine);
+    assert_eq!(visible, 0, "Tentative cells should not be visible");
+}
+
+// ── Section 5: Backspace prediction ──────────────────────────────────────────
+
+#[test]
+fn backspace_removes_last_predicted_char() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+    engine.process_input(&KeyEvent::printable('c'));
+
+    // Backspace should remove 'c' at col 2
+    let action = engine.process_input(&KeyEvent::backspace());
+    assert_eq!(action, PredictionAction::CursorMovedLeft);
+
+    // 'a' and 'b' still in overlay, 'c' removed
+    assert!(engine.overlay().get(0, 0).map(|c| c.ch) == Some('a'));
+    assert!(engine.overlay().get(1, 0).map(|c| c.ch) == Some('b'));
+    assert!(engine.overlay().get(2, 0).is_none());
+}
+
+#[test]
+fn backspace_moves_cursor_left() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+    // cursor is at col 2
+
+    engine.process_input(&KeyEvent::backspace());
+    // cursor should be at col 1
+
+    let (col, _) = engine.predicted_cursor();
+    assert_eq!(col, 1);
+}
+
+#[test]
+fn backspace_at_col_zero_does_not_underflow() {
+    let mut engine = active_engine();
+    // cursor starts at (0, 0)
+    engine.process_input(&KeyEvent::backspace());
+
+    let (col, _) = engine.predicted_cursor();
+    assert_eq!(col, 0, "Cursor should clamp to column 0");
+}
+
+#[test]
+fn type_abc_backspace_shows_ab() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+    engine.process_input(&KeyEvent::printable('c'));
+    engine.process_input(&KeyEvent::backspace());
+
+    // Only 'a' at col 0 and 'b' at col 1 should be in overlay
+    let visible: Vec<_> = engine
+        .overlay()
+        .visible_cells(engine.confirmed_epoch())
+        .map(|((col, _), cell)| (col, cell.ch))
+        .collect();
+
+    // 'c' should be gone
+    assert!(!visible.iter().any(|(_, ch)| *ch == 'c'));
+    // 'a' and 'b' should remain
+    assert!(visible.iter().any(|(_, ch)| *ch == 'a'));
+    assert!(visible.iter().any(|(_, ch)| *ch == 'b'));
+}
+
+// ── Section 6: RTT gating ─────────────────────────────────────────────────────
+
+#[test]
+fn rtt_below_20ms_engine_inactive() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(10); // Below threshold
+
+    let action = engine.process_input(&KeyEvent::printable('a'));
+    assert_eq!(action, PredictionAction::Inactive);
+    assert_eq!(visible_cell_count(&engine), 0);
+}
+
+#[test]
+fn rtt_at_0ms_engine_inactive() {
+    let mut engine = PredictionEngine::new(80, 24);
+    // RTT = 0 (default) → inactive
+
+    let action = engine.process_input(&KeyEvent::printable('a'));
+    assert_eq!(action, PredictionAction::Inactive);
+}
+
+#[test]
+fn rtt_20ms_activates_predictions() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(20);
+
+    let action = engine.process_input(&KeyEvent::printable('a'));
+    assert_eq!(
+        action,
+        PredictionAction::CharInserted {
+            col: 0,
+            row: 0,
+            ch: 'a'
+        }
+    );
+}
+
+#[test]
+fn rtt_50ms_predictions_shown_without_underline() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(50);
+
+    engine.process_input(&KeyEvent::printable('a'));
+
+    let cell = engine.overlay().get(0, 0).unwrap();
+    assert!(!cell.underlined, "At RTT=50ms, predictions should not be underlined");
+}
+
+#[test]
+fn rtt_above_80ms_predictions_underlined() {
+    let mut engine = flagging_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+
+    let cell = engine.overlay().get(0, 0).unwrap();
+    assert!(cell.underlined, "At RTT>80ms, predictions should be underlined (flagged)");
+}
+
+#[test]
+fn rtt_exactly_80ms_not_flagging() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(80);
+    // Threshold is > 80ms, not >= 80ms
+    assert!(!engine.is_flagging());
+
+    engine.process_input(&KeyEvent::printable('a'));
+    let cell = engine.overlay().get(0, 0).unwrap();
+    assert!(!cell.underlined);
+}
+
+#[test]
+fn rtt_81ms_is_flagging() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(81);
+    assert!(engine.is_flagging());
+}
+
+#[test]
+fn rtt_drops_below_threshold_deactivates_when_no_pending() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(50); // Activate
+    assert!(engine.is_active());
+
+    // Drop RTT with no pending predictions
+    engine.set_rtt(5);
+    assert!(!engine.is_active());
+}
+
+#[test]
+fn rtt_drops_but_stays_active_while_predictions_pending() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(50); // Activate
+    engine.process_input(&KeyEvent::printable('a')); // Make a prediction
+
+    // Drop RTT — should stay active since prediction is pending
+    engine.set_rtt(5);
+    assert!(
+        engine.is_active(),
+        "Should stay active while predictions are pending"
+    );
+}
+
+// ── Section 7: Bulk paste reset ───────────────────────────────────────────────
+
+#[test]
+fn bulk_paste_resets_engine() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+
+    assert!(engine.overlay().has_cells());
+
+    let bytes = vec![b'x'; 101];
+    let action = engine.process_input(&KeyEvent::bulk_paste(bytes));
+
+    assert_eq!(action, PredictionAction::Reset);
+    assert!(!engine.overlay().has_cells());
+    assert_eq!(engine.overlay().cell_count(), 0);
+}
+
+#[test]
+fn bulk_paste_resets_even_when_engine_inactive() {
+    let mut engine = PredictionEngine::new(80, 24);
+    // Engine is inactive (RTT = 0), but bulk paste should still reset
+
+    let bytes = vec![b'a'; 101];
+    let action = engine.process_input(&KeyEvent::bulk_paste(bytes));
+
+    assert_eq!(action, PredictionAction::Reset);
+}
+
+#[test]
+fn exactly_100_bytes_is_not_bulk() {
+    let bytes = vec![b'a'; 100];
+    let key = KeyEvent::from_bytes(bytes);
+    // 100 bytes is not > 100, so classify returns Uncertain (multi-byte, non-single-ASCII)
+    assert_eq!(classify(&key), InputClass::Uncertain);
+}
+
+#[test]
+fn bulk_paste_resets_epochs() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::ctrl('C')); // advance prediction_epoch
+    engine.process_input(&KeyEvent::printable('x'));
+
+    let bytes = vec![b'z'; 101];
+    engine.process_input(&KeyEvent::bulk_paste(bytes));
+
+    // After reset, both epochs should be 0
+    assert_eq!(engine.prediction_epoch(), 0);
+    assert_eq!(engine.confirmed_epoch(), 0);
+}
+
+// ── Section 8: Cursor movement prediction ────────────────────────────────────
+
+#[test]
+fn left_arrow_moves_cursor_prediction_left() {
+    let mut engine = active_engine();
+    // Move cursor to col 5 manually
+    for _ in 0..5 {
+        engine.process_input(&KeyEvent::printable('x'));
+    }
+    let (col_before, _) = engine.predicted_cursor();
+    assert_eq!(col_before, 5);
+
+    engine.process_input(&KeyEvent::arrow_left());
+
+    let (col_after, _) = engine.predicted_cursor();
+    assert_eq!(col_after, 4);
+}
+
+#[test]
+fn right_arrow_moves_cursor_prediction_right() {
+    let mut engine = active_engine();
+    // Cursor starts at col 0
+    let action = engine.process_input(&KeyEvent::arrow_right());
+
+    assert_eq!(action, PredictionAction::CursorMovedRight);
+    let (col, _) = engine.predicted_cursor();
+    assert_eq!(col, 1);
+}
+
+#[test]
+fn left_arrow_at_col_zero_does_not_underflow() {
+    let mut engine = active_engine();
+    // cursor at (0, 0)
+    engine.process_input(&KeyEvent::arrow_left());
+
+    let (col, _) = engine.predicted_cursor();
+    assert_eq!(col, 0);
+}
+
+#[test]
+fn right_arrow_clamps_at_terminal_width() {
+    let mut engine = PredictionEngine::new(10, 5);
+    engine.set_rtt(50);
+
+    // Move cursor to the last column
+    for _ in 0..15 {
+        engine.process_input(&KeyEvent::arrow_right());
+    }
+
+    let (col, _) = engine.predicted_cursor();
+    assert_eq!(col, 9, "Cursor should clamp to terminal_cols - 1 = 9");
+}
+
+#[test]
+fn arrow_keys_become_tentative() {
+    let mut engine = active_engine();
+    let epoch_before = engine.prediction_epoch();
+
+    engine.process_input(&KeyEvent::arrow_left());
+
+    assert!(engine.prediction_epoch() > epoch_before);
+}
+
+#[test]
+fn arrow_keys_do_not_predict_cell_content() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::arrow_right());
+
+    // No cell content should be predicted — only cursor movement
+    assert_eq!(engine.overlay().cell_count(), 0);
+}
+
+// ── Section 9: Epoch overflow edge cases ─────────────────────────────────────
+
+#[test]
+fn epoch_tracker_saturating_at_u64_max() {
+    let mut tracker = EpochTracker::with_epochs(u64::MAX, u64::MAX);
+    // become_tentative should not panic
+    tracker.become_tentative();
+    assert_eq!(tracker.prediction_epoch(), u64::MAX);
+}
+
+#[test]
+fn epoch_advance_confirmed_saturates() {
+    let mut tracker = EpochTracker::with_epochs(u64::MAX, u64::MAX - 1);
+    tracker.advance_confirmed();
+    assert_eq!(tracker.confirmed_epoch(), u64::MAX);
+    // Second advance should not exceed prediction_epoch
+    tracker.advance_confirmed();
+    assert_eq!(tracker.confirmed_epoch(), u64::MAX);
+}
+
+#[test]
+fn kill_epoch_at_max_does_not_panic() {
+    let mut tracker = EpochTracker::with_epochs(u64::MAX, u64::MAX);
+    let result = tracker.kill_epoch(u64::MAX);
+    // Should not panic; result is MAX (saturated)
+    assert_eq!(result, u64::MAX);
+}
+
+#[test]
+fn prediction_engine_with_max_rtt_does_not_panic() {
+    let mut engine = PredictionEngine::new(80, 24);
+    engine.set_rtt(u32::MAX);
+    assert!(engine.is_flagging());
+    // Should work normally
+    let action = engine.process_input(&KeyEvent::printable('a'));
+    assert!(matches!(action, PredictionAction::CharInserted { .. }));
+}
+
+// ── Section 10: Multi-character confirmation flow ─────────────────────────────
+
+#[test]
+fn multi_char_prediction_and_confirmation() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('h'));
+    engine.process_input(&KeyEvent::printable('e'));
+    engine.process_input(&KeyEvent::printable('l'));
+    engine.process_input(&KeyEvent::printable('l'));
+    engine.process_input(&KeyEvent::printable('o'));
+
+    // 5 cells predicted
+    assert_eq!(engine.overlay().cell_count(), 5);
+
+    // Server echoes "hello"
+    engine.process_server_output(b"hello");
+
+    // All 5 cells should be removed from the overlay (confirmed by server)
+    assert_eq!(
+        engine.overlay().cell_count(),
+        0,
+        "All predicted cells should be cleared after confirmation"
+    );
+}
+
+#[test]
+fn partial_confirmation_clears_matched_cells() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+    engine.process_input(&KeyEvent::printable('c'));
+
+    // Server echoes only "a"
+    engine.process_server_output(b"a");
+
+    // 'a' at col 0 should be cleared
+    assert!(engine.overlay().get(0, 0).is_none());
+    // 'b' at col 1 and 'c' at col 2 should remain
+    assert!(engine.overlay().get(1, 0).is_some());
+    assert!(engine.overlay().get(2, 0).is_some());
+}
+
+#[test]
+fn control_sequences_in_server_output_are_ignored() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+
+    // Server sends cursor movement + the echoed char
+    // The control sequence bytes should be skipped during comparison
+    let server_output = b"\x1b[1;1Ha";
+    engine.process_server_output(server_output);
+
+    // The 'a' should be matched — control bytes ignored
+    assert!(engine.confirmed_epoch() > 0);
+}
+
+#[test]
+fn type_then_ctrl_c_then_type_creates_visible_invisible_sequence() {
+    let mut engine = active_engine();
+
+    // Type 'a' at epoch 0 — visible
+    engine.process_input(&KeyEvent::printable('a'));
+
+    // Ctrl+C → epoch becomes 1, confirmed still 0
+    engine.process_input(&KeyEvent::ctrl('C'));
+
+    // Type 'b' at epoch 1 — invisible until epoch 1 is confirmed
+    engine.process_input(&KeyEvent::printable('b'));
+
+    let overlay = engine.overlay();
+    let confirmed = engine.confirmed_epoch();
+
+    // 'a' at epoch 0 is visible (0 <= confirmed=0)
+    let a_cell = overlay.get(0, 0);
+    assert!(a_cell.is_some());
+    assert!(a_cell.unwrap().is_visible(confirmed));
+
+    // 'b' at epoch 1 is invisible (1 > confirmed=0)
+    let b_cell = overlay.get(1, 0);
+    // 'b' might be at a different column because the cursor advanced
+    // The key invariant: no 'b' is visible
+    let any_b_visible = overlay
+        .visible_cells(confirmed)
+        .any(|(_, cell)| cell.ch == 'b');
+    assert!(!any_b_visible, "'b' should be invisible while epoch is tentative");
+}
+
+#[test]
+fn reset_clears_everything() {
+    let mut engine = active_engine();
+
+    engine.process_input(&KeyEvent::printable('a'));
+    engine.process_input(&KeyEvent::printable('b'));
+    engine.process_input(&KeyEvent::ctrl('C'));
+
+    engine.reset();
+
+    assert_eq!(engine.overlay().cell_count(), 0);
+    assert_eq!(engine.prediction_epoch(), 0);
+    assert_eq!(engine.confirmed_epoch(), 0);
+    assert!(!engine.overlay().has_cells());
+}
+
+#[test]
+fn sync_confirmed_cursor_snaps_prediction_when_no_overlay() {
+    let mut engine = active_engine();
+
+    engine.sync_confirmed_cursor(10, 3);
+
+    let (col, row) = engine.predicted_cursor();
+    assert_eq!(col, 10);
+    assert_eq!(row, 3);
+}
+
+#[test]
+fn sync_confirmed_cursor_does_not_snap_while_predictions_pending() {
+    let mut engine = active_engine();
+    engine.process_input(&KeyEvent::printable('a'));
+    // predicted cursor is now at col 1
+
+    // Server confirms cursor at col 5, but we have a pending prediction
+    engine.sync_confirmed_cursor(5, 0);
+
+    let (col, _) = engine.predicted_cursor();
+    // Predicted cursor should still be at 1, not snapped to 5
+    assert_eq!(col, 1, "Should not snap cursor while predictions are pending");
+}
+
+// ── Section 11: Terminal edge cases ──────────────────────────────────────────
+
+#[test]
+fn typing_at_right_edge_becomes_tentative() {
+    // 10-column terminal
+    let mut engine = PredictionEngine::new(10, 5);
+    engine.set_rtt(50);
+
+    // Move cursor to the last column (col 9)
+    for _ in 0..9 {
+        engine.process_input(&KeyEvent::printable('x'));
+    }
+
+    let epoch_before = engine.prediction_epoch();
+    // Type one more char at the right edge
+    engine.process_input(&KeyEvent::printable('z'));
+
+    // Should become tentative at the right margin
+    assert!(
+        engine.prediction_epoch() > epoch_before,
+        "Typing at right edge should become tentative"
+    );
+}
+
+#[test]
+fn overlay_cell_created_with_correct_epoch() {
+    let mut engine = active_engine();
+
+    // Advance to epoch 2
+    engine.process_input(&KeyEvent::ctrl('C'));
+    engine.process_input(&KeyEvent::ctrl('C'));
+    assert_eq!(engine.prediction_epoch(), 2);
+
+    // Type 'a' — cell should be tagged with epoch 2
+    engine.process_input(&KeyEvent::printable('a'));
+
+    let cell = engine.overlay().get(0, 0).unwrap();
+    assert_eq!(cell.tentative_until_epoch, 2);
+    // With confirmed_epoch = 0, this cell should be invisible
+    assert!(!cell.is_visible(0));
+    // But visible when epoch 2 is confirmed
+    assert!(cell.is_visible(2));
+}
+
+// ── Section 12: Input classification ─────────────────────────────────────────
+
+#[test]
+fn classify_all_printable_ascii_range() {
+    for byte in 0x20u8..=0x7eu8 {
+        let key = KeyEvent {
+            bytes: vec![byte],
+            ctrl_held: false,
+        };
+        let class = classify(&key);
+        assert_eq!(
+            class,
+            InputClass::Predictable(byte as char),
+            "byte 0x{:02x} should be Predictable",
+            byte
+        );
+    }
+}
+
+#[test]
+fn classify_all_ctrl_chars_uncertain() {
+    // Ctrl+A through Ctrl+Z
+    for ch in b'A'..=b'Z' {
+        let key = KeyEvent::ctrl(ch as char);
+        assert_eq!(
+            classify(&key),
+            InputClass::Uncertain,
+            "Ctrl+{} should be Uncertain",
+            ch as char
+        );
+    }
+}
+
+#[test]
+fn classify_backspace_correct() {
+    assert_eq!(classify(&KeyEvent::backspace()), InputClass::Backspace);
+}
+
+#[test]
+fn classify_arrows_correct() {
+    assert_eq!(classify(&KeyEvent::arrow_left()), InputClass::ArrowLeft);
+    assert_eq!(classify(&KeyEvent::arrow_right()), InputClass::ArrowRight);
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -33,6 +33,7 @@ use std::sync::{Arc, Mutex};
 
 use std::time::Instant;
 
+use crate::prediction::{KeyEvent as PredKeyEvent, PredictionEngine};
 use alacritty_terminal::Term;
 use alacritty_terminal::event::EventListener;
 use alacritty_terminal::grid::{Dimensions, Scroll};
@@ -219,6 +220,13 @@ pub struct TerminalPane {
 
     /// Viewport cell under the mouse cursor (for hyperlink hover detection).
     hover_cell: Option<(usize, usize)>,
+
+    /// Mosh-style local keystroke prediction engine.
+    ///
+    /// Maintains a sparse overlay of speculatively-rendered characters that are
+    /// painted on top of the confirmed alacritty_terminal state. Inactive below
+    /// 20ms RTT; call `prediction.set_rtt(ms)` to activate.
+    pub prediction: PredictionEngine,
 }
 
 impl TerminalPane {
@@ -309,6 +317,7 @@ impl TerminalPane {
             last_click_cell: (0, 0),
             click_count: 0,
             hover_cell: None,
+            prediction: PredictionEngine::new(cols as u16, rows as u16),
         })
     }
 
@@ -400,6 +409,7 @@ impl TerminalPane {
             last_click_cell: (0, 0),
             click_count: 0,
             hover_cell: None,
+            prediction: PredictionEngine::new(cols as u16, rows as u16),
         })
     }
 
@@ -441,6 +451,7 @@ impl TerminalPane {
             last_click_cell: (0, 0),
             click_count: 0,
             hover_cell: None,
+            prediction: PredictionEngine::new(cols as u16, rows as u16),
         }
     }
 
@@ -452,6 +463,10 @@ impl TerminalPane {
     /// Drain all pending PTY output bytes from the channel and feed them to the
     /// terminal state machine.
     ///
+    /// Also feeds server output to the prediction engine so it can confirm or
+    /// discard speculative predictions. After processing all chunks, syncs the
+    /// confirmed cursor position from the alacritty Term grid.
+    ///
     /// Must be called from the main thread (render loop) before each frame.
     pub fn drain_output(&mut self) {
         let mut collected: Vec<Vec<u8>> = Vec::new();
@@ -462,9 +477,33 @@ impl TerminalPane {
             return;
         }
         let mut term = self.term.lock().unwrap();
+        for chunk in &collected {
+            // Feed bytes to the prediction engine for confirmation/mismatch detection
+            // before advancing the terminal state machine. This lets the engine compare
+            // its predicted bytes against the server's echo before the Term grid is updated.
+            self.prediction.process_server_output(chunk);
+        }
         for chunk in collected {
             self.processor.advance(&mut *term, &chunk);
         }
+
+        // After advancing the Term, check alternate-screen mode (vim, htop, etc.).
+        // When in alt-screen, reset all predictions and deactivate — we cannot safely
+        // predict terminal state inside modal applications. This is the primary safety
+        // gate for tmux-backed sessions where the inner pane may run vim at any time.
+        if term.mode().contains(TermMode::ALT_SCREEN) {
+            self.prediction.reset();
+            self.prediction.set_rtt(0); // deactivate until alt-screen exits
+        }
+
+        // After all server output is processed, snap the confirmed cursor position
+        // from the updated alacritty Term grid. This keeps the prediction engine's
+        // reference cursor in sync with the server's authoritative state.
+        let cursor = term.grid().cursor.point;
+        self.prediction.sync_confirmed_cursor(
+            cursor.column.0 as u16,
+            cursor.line.0 as u16,
+        );
     }
 
     /// Resize the terminal to fit the given pixel area.
@@ -498,12 +537,20 @@ impl TerminalPane {
         let new_size = TermSize::new(new_cols, new_rows);
         let mut term = self.term.lock().unwrap();
         term.resize(new_size);
+
+        // A resize invalidates all in-flight predictions — the server will redraw
+        // the full terminal. reset() is called internally by set_terminal_size().
+        self.prediction.set_terminal_size(new_cols as u16, new_rows as u16);
     }
 
     /// Write a key event to the PTY.
     ///
     /// Should be called when the terminal screen is active and a key is pressed.
     /// Returns `true` if the key was consumed (written to the PTY).
+    ///
+    /// Also feeds the keystroke to the prediction engine BEFORE sending to the
+    /// server, so the overlay is updated synchronously with the current render
+    /// frame. The bytes sent to the server are not modified.
     pub fn write_key(&mut self, key: &Key, ctrl_held: bool) -> bool {
         let app_cursor = {
             let term = self.term.lock().unwrap();
@@ -513,6 +560,30 @@ impl TerminalPane {
         if bytes.is_empty() {
             return false;
         }
+
+        // Feed keystroke to prediction engine before sending to server.
+        // This ensures the overlay is updated immediately (this render frame)
+        // rather than waiting for the server echo (next frame after RTT).
+        //
+        // Alternate screen detection: disable predictions in vim/htop/etc.
+        // When ALT_SCREEN is active, the terminal is in a modal application
+        // that we cannot safely predict — reset and deactivate.
+        let is_alt_screen = {
+            let term = self.term.lock().unwrap();
+            term.mode().contains(TermMode::ALT_SCREEN)
+        };
+        if is_alt_screen {
+            // Suppress predictions while in alternate screen mode.
+            // Do not reset here — just skip updating the engine so predictions
+            // remain cleared (reset is called when entering alt screen via drain_output).
+        } else {
+            let pred_key = PredKeyEvent {
+                bytes: bytes.clone(),
+                ctrl_held,
+            };
+            self.prediction.process_input(&pred_key);
+        }
+
         let _ = self.pty_writer.write_all(&bytes);
         let _ = self.pty_writer.flush();
         true
@@ -968,6 +1039,87 @@ impl TerminalPane {
                 .brush(&color)
                 .draw(Fill::NonZero, glyphs.into_iter());
         }
+
+        // --- Phase 2: Paint prediction overlay on top of confirmed terminal state ---
+        //
+        // The overlay is a sparse set of speculatively-rendered characters maintained
+        // by PredictionEngine. We paint them here, after the confirmed cell grid has
+        // been flushed, so predictions visually override any confirmed cell beneath them.
+        //
+        // visible_cells() filters by the confirmed epoch — only cells whose tentative
+        // epoch has been reached by confirmed server output are shown. No manual epoch
+        // checking is required here.
+        if self.prediction.is_active() {
+            let confirmed_epoch = self.prediction.confirmed_epoch();
+
+            // Collect predicted glyph data.
+            let mut predicted_glyphs: Vec<Glyph> = Vec::new();
+            let mut underline_rects: Vec<Rect> = Vec::new();
+
+            for ((col, row), overlay_cell) in self.prediction.overlay().visible_cells(confirmed_epoch) {
+                let col = col as usize;
+                let row = row as usize;
+                if col >= self.cols || row >= self.rows {
+                    continue;
+                }
+                let cell_x = offset_x + col as f64 * cw;
+                let cell_y = offset_y + row as f64 * ch;
+
+                // Predicted characters use the same foreground color as normal text.
+                // No background override — they sit on top of whatever confirmed state is below.
+                let font_ref = skrifa::FontRef::from_index(self.font.data.as_ref(), self.font.index);
+                if let Ok(font_ref) = font_ref {
+                    use skrifa::MetadataProvider;
+                    let charmap = font_ref.charmap();
+                    let gid = charmap.map(overlay_cell.ch).unwrap_or_default();
+                    let baseline_y = cell_y + ch * 0.8;
+                    predicted_glyphs.push(Glyph {
+                        id: gid.to_u32(),
+                        x: cell_x as f32,
+                        y: baseline_y as f32,
+                    });
+                }
+
+                // Underline the prediction when RTT > 80ms (flagging mode, matches Mosh behavior).
+                if overlay_cell.underlined {
+                    let underline_y = cell_y + ch - 2.0;
+                    underline_rects.push(Rect::new(
+                        cell_x, underline_y,
+                        cell_x + cw, underline_y + HYPERLINK_UNDERLINE_PX,
+                    ));
+                }
+            }
+
+            // Flush predicted glyphs in a single batch using the default foreground color.
+            if !predicted_glyphs.is_empty() {
+                scene
+                    .draw_glyphs(&self.font)
+                    .font_size(self.font_size)
+                    .brush(&TERM_FG)
+                    .draw(Fill::NonZero, predicted_glyphs.into_iter());
+            }
+
+            // Draw underlines for flagged predictions (RTT > 80ms).
+            for rect in underline_rects {
+                scene.fill(Fill::NonZero, Affine::IDENTITY, TERM_FG, None, &rect);
+            }
+
+            // Draw the predicted cursor on top of the overlay glyphs.
+            // The predicted cursor advances ahead of the confirmed cursor by one
+            // column per typed character, giving the appearance of instant response.
+            let (pred_col, pred_row) = self.prediction.predicted_cursor();
+            let pred_col = pred_col as usize;
+            let pred_row = pred_row as usize;
+            if pred_col < self.cols && pred_row < self.rows {
+                let cx = offset_x + pred_col as f64 * cw;
+                let cy = offset_y + pred_row as f64 * ch;
+                let cursor_rect = Rect::new(cx, cy, cx + cw, cy + ch);
+                // Use a slightly transparent cursor to distinguish predicted from confirmed.
+                const TERM_CURSOR_PREDICTED: Color = Color::new([0.40, 0.26, 0.13, 0.55]);
+                scene.fill(Fill::NonZero, Affine::IDENTITY, TERM_CURSOR_PREDICTED, None, &cursor_rect);
+            }
+        }
+        // --- End prediction overlay ---
 
         // Draw cursor.
         if self.cursor_visible {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -29,10 +29,12 @@
 //! ```
 
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use std::time::Instant;
 
+use crate::app_event::AppEvent;
 use crate::prediction::{KeyEvent as PredKeyEvent, PredictionEngine};
 use alacritty_terminal::Term;
 use alacritty_terminal::event::EventListener;
@@ -1052,9 +1054,19 @@ impl TerminalPane {
         if self.prediction.is_active() {
             let confirmed_epoch = self.prediction.confirmed_epoch();
 
-            // Collect predicted glyph data.
-            let mut predicted_glyphs: Vec<Glyph> = Vec::new();
-            let mut underline_rects: Vec<Rect> = Vec::new();
+            // Collect predicted glyph data batched by foreground color.
+            //
+            // For each overlay cell we query the confirmed terminal grid cell at the
+            // same (col, row) position and extract its actual foreground color via
+            // resolve_cell_colors(). This prevents the jarring color flash that
+            // occurs when a prediction is rendered in black (TERM_FG) but the
+            // confirmed cell uses a different color (e.g. colored prompt, syntax
+            // highlighting). We mirror the Phase 1 batching pattern: Vec<(Color,
+            // Vec<Glyph>)>, so that cells sharing the same color are drawn in a
+            // single draw_glyphs() call.
+            let mut predicted_glyph_batches: Vec<(Color, Vec<Glyph>)> = Vec::new();
+            // Underline rectangles paired with their per-cell foreground color.
+            let mut underline_rects: Vec<(Color, Rect)> = Vec::new();
 
             for ((col, row), overlay_cell) in self.prediction.overlay().visible_cells(confirmed_epoch) {
                 let col = col as usize;
@@ -1065,43 +1077,61 @@ impl TerminalPane {
                 let cell_x = offset_x + col as f64 * cw;
                 let cell_y = offset_y + row as f64 * ch;
 
-                // Predicted characters use the same foreground color as normal text.
-                // No background override — they sit on top of whatever confirmed state is below.
+                // Determine the foreground color to use for this predicted character.
+                //
+                // Strategy: look up the confirmed grid cell at this (col, row) position
+                // and resolve its foreground color. If the grid lookup fails for any
+                // reason (e.g. the position is out of the scrollback grid bounds) we
+                // fall back to TERM_FG.
+                let overlay_fg_color = {
+                    let grid_point = Self::viewport_to_grid_point(col, row, display_offset);
+                    let grid_cell = &term.grid()[grid_point];
+                    let (_, fg) = resolve_cell_colors(grid_cell, colors);
+                    fg
+                };
+
+                // Accumulate glyph into the batch for this color.
                 let font_ref = skrifa::FontRef::from_index(self.font.data.as_ref(), self.font.index);
                 if let Ok(font_ref) = font_ref {
                     use skrifa::MetadataProvider;
                     let charmap = font_ref.charmap();
                     let gid = charmap.map(overlay_cell.ch).unwrap_or_default();
                     let baseline_y = cell_y + ch * 0.8;
-                    predicted_glyphs.push(Glyph {
+                    let glyph = Glyph {
                         id: gid.to_u32(),
                         x: cell_x as f32,
                         y: baseline_y as f32,
-                    });
+                    };
+                    if let Some(batch) = predicted_glyph_batches.iter_mut().find(|(c, _)| *c == overlay_fg_color) {
+                        batch.1.push(glyph);
+                    } else {
+                        predicted_glyph_batches.push((overlay_fg_color, vec![glyph]));
+                    }
                 }
 
                 // Underline the prediction when RTT > 80ms (flagging mode, matches Mosh behavior).
+                // Use the same per-cell color so the underline also matches the confirmed style.
                 if overlay_cell.underlined {
                     let underline_y = cell_y + ch - 2.0;
-                    underline_rects.push(Rect::new(
+                    underline_rects.push((overlay_fg_color, Rect::new(
                         cell_x, underline_y,
                         cell_x + cw, underline_y + HYPERLINK_UNDERLINE_PX,
-                    ));
+                    )));
                 }
             }
 
-            // Flush predicted glyphs in a single batch using the default foreground color.
-            if !predicted_glyphs.is_empty() {
+            // Flush predicted glyph batches — one draw call per distinct foreground color.
+            for (color, glyphs) in predicted_glyph_batches {
                 scene
                     .draw_glyphs(&self.font)
                     .font_size(self.font_size)
-                    .brush(&TERM_FG)
-                    .draw(Fill::NonZero, predicted_glyphs.into_iter());
+                    .brush(&color)
+                    .draw(Fill::NonZero, glyphs.into_iter());
             }
 
-            // Draw underlines for flagged predictions (RTT > 80ms).
-            for rect in underline_rects {
-                scene.fill(Fill::NonZero, Affine::IDENTITY, TERM_FG, None, &rect);
+            // Draw underlines for flagged predictions (RTT > 80ms), using per-cell color.
+            for (color, rect) in underline_rects {
+                scene.fill(Fill::NonZero, Affine::IDENTITY, color, None, &rect);
             }
 
             // Draw the predicted cursor on top of the overlay glyphs.


### PR DESCRIPTION
## Summary

- Fixes the jarring color flash when prediction overlay cells render in black (`TERM_FG`) but the confirmed cell uses a different foreground color (e.g. colored shell prompt, syntax-highlighted output)
- For each overlay cell, queries `term.grid()` at `(col, row)` and resolves its foreground color via the existing `resolve_cell_colors()` helper
- Batches predicted glyphs by color using the same `Vec<(Color, Vec<Glyph>)>` pattern as Phase 1 confirmed-cell rendering (single draw call per distinct color)
- Applies per-cell color to underline rectangles (RTT > 80ms flagging mode) so they also match the confirmed style

## Key functional patterns

- **Pure color resolution**: `resolve_cell_colors()` is a pure function; no side effects introduced
- **Color batching by key**: mirrors the Phase 1 `fg_glyphs: Vec<(Color, Vec<Glyph>)>` accumulator pattern
- **Read at render time**: color is read from `term.grid()` at render time, keeping `OverlayCell` struct pure (no stored color state)
- **Fallback to TERM_FG**: `resolve_cell_colors` already falls back to `TERM_FG` for default/unnamed colors

## Testing approach

- `cargo build`: passes (no new errors)
- `cargo test`: 164 pass, 1 pre-existing failure (`sanitize_blocks_path_traversal` — unrelated)

Closes #39. References #38.