### PR TITLE
feat(terminal): event-driven PTY rendering via AppEvent::PtyData

### DIFF
--- a/src/app_event.rs
+++ b/src/app_event.rs
@@ -1,0 +1,17 @@
+//! Custom winit user events for bisque-computer.
+//!
+//! `EventLoop::<AppEvent>` replaces the default unit-typed loop so background
+//! threads can wake the main event loop without going through a window event.
+
+/// Application-level events sent via `EventLoopProxy::send_event()`.
+#[derive(Debug, Clone)]
+pub enum AppEvent {
+    /// New bytes have arrived from a PTY reader thread.
+    ///
+    /// The main event loop handles this by calling `drain_all_output()` on
+    /// the pane tree and requesting an immediate redraw, eliminating the
+    /// ~16ms frame-rate polling latency floor. The coalescing dirty flag in
+    /// each `TerminalPane` ensures at most one `PtyData` event is in-flight
+    /// per pane at any time; rapid bursts do not flood the event queue.
+    PtyData,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@
 //! Mouse events for text selection are routed through `text_selection::SelectableText`
 //! instances, backed by `parley::PlainEditor`.
 
+mod app_event;
 mod dashboard;
 #[allow(dead_code)]
 mod design;
@@ -68,7 +69,8 @@ use vello::{AaConfig, Renderer, RendererOptions, Scene};
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalPosition;
 use winit::event::{ElementState, KeyEvent, Modifiers, MouseButton, WindowEvent};
-use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use app_event::AppEvent;
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Fullscreen, Window};
 
@@ -263,6 +265,8 @@ struct App {
 
     // --- Terminal ---
     pane_tree: Option<PaneTree>,
+    /// Event-loop proxy for waking the render thread from background threads.
+    proxy: EventLoopProxy<AppEvent>,
     /// Last cursor blink instant.
     last_blink: Instant,
 
@@ -385,7 +389,7 @@ impl App {
     }
 }
 
-impl ApplicationHandler for App {
+impl ApplicationHandler<AppEvent> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.render_state else {
             return;
@@ -1333,6 +1337,21 @@ impl ApplicationHandler for App {
         }
     }
 
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: AppEvent) {
+        match event {
+            AppEvent::PtyData => {
+                // Drain queued PTY bytes and request an immediate repaint,
+                // bypassing the WaitUntil cursor-blink timer entirely.
+                if let Some(tree) = &mut self.pane_tree {
+                    tree.drain_all_output();
+                }
+                if let RenderState::Active { window, .. } = &self.render_state {
+                    window.request_redraw();
+                }
+            }
+        }
+    }
+
     fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
         // Triggered by WaitUntil expiry (cursor blink) or external wakeup.
         // Re-request a redraw so the terminal cursor blinks.
@@ -1452,14 +1471,19 @@ fn main() -> Result<()> {
         initialized.into()
     };
 
+    // Create the event loop and proxy before spawning the pane tree so the
+    // PTY reader threads can wake the winit event loop when bytes arrive.
+    let event_loop = EventLoop::<AppEvent>::with_user_event().build()?;
+    let proxy = event_loop.create_proxy();
+
     // Spawn terminal pane tree. Use Docker backend when --docker is set,
     // otherwise fall back to a local PTY shell.
     let pane_tree = if args.docker {
         info!("Terminal: using Docker backend");
-        PaneTree::with_backend(1280.0, 800.0, pane_tree::TerminalBackend::Docker)
+        PaneTree::with_backend(1280.0, 800.0, pane_tree::TerminalBackend::Docker, proxy.clone())
     } else {
         info!("Terminal: using local PTY backend");
-        PaneTree::new(1280.0, 800.0)
+        PaneTree::new(1280.0, 800.0, proxy.clone())
     };
     if pane_tree.is_some() {
         info!("Terminal: pane tree spawned successfully");
@@ -1508,11 +1532,11 @@ fn main() -> Result<()> {
         animating: false,
         last_frame: now,
         pane_tree,
+        proxy,
         last_blink: now,
         design_repl: design_repl::DesignRepl::new(),
     };
 
-    let event_loop = EventLoop::new()?;
     event_loop
         .run_app(&mut app)
         .expect("Couldn't run event loop");

--- a/src/pane_tree.rs
+++ b/src/pane_tree.rs
@@ -9,7 +9,9 @@ use vello::kurbo::{Affine, Rect};
 use vello::peniko::{Color, Fill};
 use vello::Scene;
 
+use crate::app_event::AppEvent;
 use crate::terminal::TerminalPane;
+use winit::event_loop::EventLoopProxy;
 
 /// The Dockerfile embedded in the binary at compile time.
 const DOCKERFILE: &str = include_str!("../docker/Dockerfile");
@@ -114,23 +116,31 @@ pub struct PaneTree {
     focus_path: Vec<FocusChild>,
     /// Backend configuration for spawning new panes.
     backend: TerminalBackend,
+    /// Event-loop proxy for waking the render thread on PTY output.
+    proxy: EventLoopProxy<AppEvent>,
 }
 
 impl PaneTree {
     /// Create a new pane tree with a single terminal pane.
     ///
     /// Uses the `Local` backend by default (existing behavior).
-    pub fn new(width: f64, height: f64) -> Option<Self> {
-        Self::with_backend(width, height, TerminalBackend::Local)
+    pub fn new(width: f64, height: f64, proxy: EventLoopProxy<AppEvent>) -> Option<Self> {
+        Self::with_backend(width, height, TerminalBackend::Local, proxy)
     }
 
     /// Create a new pane tree with a specific backend.
-    pub fn with_backend(width: f64, height: f64, backend: TerminalBackend) -> Option<Self> {
-        let pane = spawn_pane_for_backend(&backend, width, height)?;
+    pub fn with_backend(
+        width: f64,
+        height: f64,
+        backend: TerminalBackend,
+        proxy: EventLoopProxy<AppEvent>,
+    ) -> Option<Self> {
+        let pane = spawn_pane_for_backend(&backend, width, height, proxy.clone())?;
         Some(Self {
             root: Some(PaneNode::Leaf(pane)),
             focus_path: Vec::new(),
             backend,
+            proxy,
         })
     }
 
@@ -157,7 +167,7 @@ impl PaneTree {
             return;
         }
 
-        let new_pane = match spawn_pane_for_backend(&self.backend, second_w, second_h) {
+        let new_pane = match spawn_pane_for_backend(&self.backend, second_w, second_h, self.proxy.clone()) {
             Some(pane) => pane,
             None => {
                 warn!("Failed to spawn new terminal pane for split");
@@ -496,13 +506,14 @@ fn spawn_pane_for_backend(
     backend: &TerminalBackend,
     width: f64,
     height: f64,
+    proxy: EventLoopProxy<AppEvent>,
 ) -> Option<TerminalPane> {
     match backend {
-        TerminalBackend::Local => TerminalPane::spawn(width, height),
+        TerminalBackend::Local => TerminalPane::spawn(width, height, proxy),
         TerminalBackend::Docker => {
             if !ensure_docker_image() {
                 warn!("Docker image unavailable — falling back to local PTY");
-                return TerminalPane::spawn(width, height);
+                return TerminalPane::spawn(width, height, proxy);
             }
 
             info!(image = DOCKER_IMAGE, "Spawning Docker container for Claude Code");
@@ -530,6 +541,7 @@ fn spawn_pane_for_backend(
                 "docker",
                 &args_refs,
                 &[],
+                proxy,
             )
         }
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -30,8 +30,12 @@
 
 use std::io::Write;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use std::time::Instant;
+
+use crate::app_event::AppEvent;
+use winit::event_loop::EventLoopProxy;
 
 use crate::prediction::{KeyEvent as PredKeyEvent, PredictionEngine};
 use alacritty_terminal::Term;
@@ -183,6 +187,12 @@ pub struct TerminalPane {
     /// Buffered PTY output bytes from the reader thread.
     rx: tokio_mpsc::UnboundedReceiver<Vec<u8>>,
 
+    /// Coalescing flag: set by the reader thread when it sends PTY bytes and
+    /// a `PtyData` event. Cleared by `drain_output()` before draining the
+    /// channel, so rapid bursts do not flood the winit event queue with more
+    /// than one in-flight `PtyData` event per pane.
+    pty_dirty: Arc<AtomicBool>,
+
     /// Write handle to the backend (sends input to the shell/VM).
     pty_writer: Box<dyn Write + Send>,
 
@@ -234,7 +244,7 @@ impl TerminalPane {
     ///
     /// `width` and `height` are the pixel dimensions of the terminal area.
     /// Returns `None` if PTY creation or shell spawn fails.
-    pub fn spawn(width: f64, height: f64) -> Option<Self> {
+    pub fn spawn(width: f64, height: f64, proxy: EventLoopProxy<AppEvent>) -> Option<Self> {
         // Build font (Monaco preferred, Cascadia Code fallback) and compute cell dimensions.
         let font_data = load_terminal_font();
         let (cell_width, cell_height) = compute_cell_size(&font_data, DEFAULT_FONT_SIZE);
@@ -274,10 +284,14 @@ impl TerminalPane {
         let reader = pair.master.try_clone_reader().ok()?;
         let writer = pair.master.take_writer().ok()?;
 
-        // Spawn the PTY reader thread.
+        // Spawn the PTY reader thread with event-driven wakeup.
+        // The dirty flag coalesces rapid bursts: only the first byte in each
+        // burst fires a PtyData event; subsequent bytes are silently queued.
+        let dirty = Arc::new(AtomicBool::new(false));
         let (tx, rx) = tokio_mpsc::unbounded_channel::<Vec<u8>>();
         {
             let tx = tx.clone();
+            let dirty_reader = dirty.clone();
             std::thread::spawn(move || {
                 let mut reader = reader;
                 let mut buf = [0u8; 4096];
@@ -286,6 +300,11 @@ impl TerminalPane {
                         Ok(0) | Err(_) => break,
                         Ok(n) => {
                             let _ = tx.send(buf[..n].to_vec());
+                            // Only send PtyData on the false→true transition so
+                            // a rapid burst sends at most one wakeup event.
+                            if !dirty_reader.swap(true, Ordering::Relaxed) {
+                                let _ = proxy.send_event(AppEvent::PtyData);
+                            }
                         }
                     }
                 }
@@ -301,6 +320,7 @@ impl TerminalPane {
             term,
             processor: Processor::new(),
             rx,
+            pty_dirty: dirty,
             pty_writer: writer,
             pty_resize: Box::new(LocalPtyResize(pair.master)),
             font: font_data,
@@ -331,6 +351,7 @@ impl TerminalPane {
         cmd: &str,
         args: &[&str],
         env: &[(&str, &str)],
+        proxy: EventLoopProxy<AppEvent>,
     ) -> Option<Self> {
         let font_data = load_terminal_font();
         let (cell_width, cell_height) = compute_cell_size(&font_data, DEFAULT_FONT_SIZE);
@@ -368,9 +389,11 @@ impl TerminalPane {
         let reader = pair.master.try_clone_reader().ok()?;
         let writer = pair.master.take_writer().ok()?;
 
+        let dirty = Arc::new(AtomicBool::new(false));
         let (tx, rx) = tokio_mpsc::unbounded_channel::<Vec<u8>>();
         {
             let tx = tx.clone();
+            let dirty_reader = dirty.clone();
             std::thread::spawn(move || {
                 let mut reader = reader;
                 let mut buf = [0u8; 4096];
@@ -379,6 +402,9 @@ impl TerminalPane {
                         Ok(0) | Err(_) => break,
                         Ok(n) => {
                             let _ = tx.send(buf[..n].to_vec());
+                            if !dirty_reader.swap(true, Ordering::Relaxed) {
+                                let _ = proxy.send_event(AppEvent::PtyData);
+                            }
                         }
                     }
                 }
@@ -393,6 +419,7 @@ impl TerminalPane {
             term,
             processor: Processor::new(),
             rx,
+            pty_dirty: dirty,
             pty_writer: writer,
             pty_resize: Box::new(LocalPtyResize(pair.master)),
             font: font_data,
@@ -435,6 +462,8 @@ impl TerminalPane {
             term,
             processor: Processor::new(),
             rx,
+            // VM streams do not have a proxy — use a no-op dirty flag.
+            pty_dirty: Arc::new(AtomicBool::new(false)),
             pty_writer: writer,
             pty_resize: resizer,
             font: font_data,
@@ -469,6 +498,9 @@ impl TerminalPane {
     ///
     /// Must be called from the main thread (render loop) before each frame.
     pub fn drain_output(&mut self) {
+        // Clear the dirty flag BEFORE draining so any bytes that arrive
+        // after the channel appears empty will trigger a fresh PtyData event.
+        self.pty_dirty.store(false, Ordering::Relaxed);
         let mut collected: Vec<Vec<u8>> = Vec::new();
         while let Ok(chunk) = self.rx.try_recv() {
             collected.push(chunk);


### PR DESCRIPTION
## Summary

Closes #40. Eliminates the ~16ms latency floor caused by `WaitUntil` frame-rate polling by wiring PTY reader threads directly into the winit event loop via a custom `AppEvent::PtyData` user event.

- **`src/app_event.rs`** (new): defines `AppEvent::PtyData` — the custom winit user event that background PTY reader threads inject to wake the main event loop
- **`src/terminal.rs`**: adds `Arc<AtomicBool>` `pty_dirty` coalescing flag to `TerminalPane`; `spawn()` and `spawn_command()` now accept an `EventLoopProxy<AppEvent>` and fire `PtyData` on the `false→true` dirty transition (at most one event per burst); `drain_output()` clears the flag before draining the channel to prevent a race where bytes arriving after the channel appears empty would miss their wakeup
- **`src/pane_tree.rs`**: stores `EventLoopProxy<AppEvent>` in `PaneTree`; threads it through `new()`, `with_backend()`, `split_focused()`, and `spawn_pane_for_backend()`
- **`src/main.rs`**: switches to `EventLoop::<AppEvent>::with_user_event().build()`; implements `ApplicationHandler<AppEvent>::user_event()` to drain output and call `window.request_redraw()` immediately; creates the proxy before pane tree construction so reader threads can start sending wakeups from the first byte

## Functional patterns used

- `Arc<AtomicBool>` for lock-free coalescing: the `swap(true, Relaxed)` + `store(false, Relaxed)` pattern ensures O(1) event rate independent of PTY throughput
- Pure data flow: each `TerminalPane` owns its dirty flag; no shared global state
- Boundary isolation: the `EventLoopProxy` side effect is isolated to the reader thread; `drain_output()` remains a pure synchronous operation on the main thread

## Test plan

- [x] `cargo build` passes with no errors (25 pre-existing warnings, all unrelated)
- [x] `cargo test` passes: 164 passed, 1 pre-existing failure (`vm::drop_server::tests::sanitize_blocks_path_traversal` fails on main too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)